### PR TITLE
created voting endpoints

### DIFF
--- a/src/main/java/dsd/api/cdmsa/controller/RfcController.java
+++ b/src/main/java/dsd/api/cdmsa/controller/RfcController.java
@@ -1,6 +1,6 @@
 package dsd.api.cdmsa.controller;
 
-import dsd.api.cdmsa.dto.CreateCommentRequest;
+import dsd.api.cdmsa.dto.*;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,11 +12,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import dsd.api.cdmsa.dto.AlternativeResponse;
-import dsd.api.cdmsa.dto.CloseRfcRequest;
-import dsd.api.cdmsa.dto.CreateAlternativeRequest;
-import dsd.api.cdmsa.dto.CreateRfcRequest;
-import dsd.api.cdmsa.dto.RfcResponse;
 import dsd.api.cdmsa.service.RfcService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -144,5 +139,19 @@ public class RfcController {
         Long userId = getCurrentUserId(httpRequest);
         RfcResponse response = rfcService.closeRfc(rfcId, userId, request);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/alternatives/{altId}/vote")
+    public ResponseEntity<VoteResponse> voteForAlternative(
+            @PathVariable Long altId,
+            @RequestBody VoteRequest voteRequest,
+            HttpServletRequest httpRequest) {
+
+        // check if user is a reviewer, probably we need also the rfcId to see status = under review
+        Long userId = getCurrentUserId(httpRequest);
+
+        VoteResponse resp = rfcService.voteForAlternative(altId, userId, voteRequest.outcome());
+
+        return ResponseEntity.ok(resp);
     }
 }

--- a/src/main/java/dsd/api/cdmsa/dto/AlternativeResponse.java
+++ b/src/main/java/dsd/api/cdmsa/dto/AlternativeResponse.java
@@ -11,7 +11,9 @@ public record AlternativeResponse(
         Long authorId,
         String authorName,
         java.time.Instant createdAt,
-        java.time.Instant updatedAt) {
+        java.time.Instant updatedAt,
+        int yes,
+        int no) {
 
     public static AlternativeResponse fromEntity(Alternative alternative) {
         return new AlternativeResponse(
@@ -23,6 +25,21 @@ public record AlternativeResponse(
                 alternative.getAuthor() != null ? alternative.getAuthor().getId() : null,
                 alternative.getAuthor() != null ? alternative.getAuthor().getName() : null,
                 alternative.getCreatedAt(),
-                alternative.getUpdatedAt());
+                alternative.getUpdatedAt(),
+                0,
+                0);
+    }
+
+    public static AlternativeResponse fromEntityVotes(Alternative alternative, int yes, int no) {
+        return new AlternativeResponse(
+                alternative.getId(),
+                alternative.getTitle(),
+                alternative.getDescription(),
+                alternative.getPros(),
+                alternative.getCons(),
+                alternative.getAuthor() != null ? alternative.getAuthor().getId() : null,
+                alternative.getAuthor() != null ? alternative.getAuthor().getName() : null,
+                alternative.getCreatedAt(),
+                alternative.getUpdatedAt(), yes, no);
     }
 }

--- a/src/main/java/dsd/api/cdmsa/dto/VoteRequest.java
+++ b/src/main/java/dsd/api/cdmsa/dto/VoteRequest.java
@@ -1,0 +1,6 @@
+package dsd.api.cdmsa.dto;
+
+public record VoteRequest(
+        Boolean outcome) {
+}
+

--- a/src/main/java/dsd/api/cdmsa/dto/VoteResponse.java
+++ b/src/main/java/dsd/api/cdmsa/dto/VoteResponse.java
@@ -1,0 +1,5 @@
+package dsd.api.cdmsa.dto;
+
+public record VoteResponse(int yesCount, int noCount) {}
+
+

--- a/src/main/java/dsd/api/cdmsa/model/Vote.java
+++ b/src/main/java/dsd/api/cdmsa/model/Vote.java
@@ -1,0 +1,31 @@
+package dsd.api.cdmsa.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+@Entity
+@Table(name = "votes")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Vote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "alternative_id", nullable = false)
+    private Alternative alternative;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "voter_id", nullable = false)
+    private User voter;
+
+    @NotNull
+    @Column(nullable = false)
+    private Boolean outcome;        // true means u like the alternative, false means not
+
+}

--- a/src/main/java/dsd/api/cdmsa/repository/VoteRepository.java
+++ b/src/main/java/dsd/api/cdmsa/repository/VoteRepository.java
@@ -1,0 +1,17 @@
+package dsd.api.cdmsa.repository;
+
+import dsd.api.cdmsa.model.Alternative;
+import dsd.api.cdmsa.model.User;
+import dsd.api.cdmsa.model.Vote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+    // Find user's vote on a specific alternative
+    Optional<Vote> findByAlternativeAndVoter(Alternative alternative, User voter);
+
+    // Counts # of yes or no of an alternative
+    int countByAlternativeAndOutcome(Alternative alternative, boolean outcome);
+}
+

--- a/src/main/java/dsd/api/cdmsa/service/RfcService.java
+++ b/src/main/java/dsd/api/cdmsa/service/RfcService.java
@@ -1,37 +1,25 @@
 package dsd.api.cdmsa.service;
 
-import dsd.api.cdmsa.dto.CreateCommentRequest;
-import dsd.api.cdmsa.model.Comment;
+import dsd.api.cdmsa.dto.*;
+import dsd.api.cdmsa.model.*;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import dsd.api.cdmsa.repository.*;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import dsd.api.cdmsa.dto.AlternativeResponse;
-import dsd.api.cdmsa.dto.CommentResponse;
-import dsd.api.cdmsa.dto.CloseRfcRequest;
-import dsd.api.cdmsa.dto.CreateAlternativeRequest;
-import dsd.api.cdmsa.dto.CreateRfcRequest;
-import dsd.api.cdmsa.dto.RfcResponse;
 import dsd.api.cdmsa.exception.RfcAlternativeBadRequestException;
 import dsd.api.cdmsa.exception.RfcAlternativeNotAllowedException;
 import dsd.api.cdmsa.exception.RfcBadRequestException;
 import dsd.api.cdmsa.exception.RfcDependencyNotFoundException;
 import dsd.api.cdmsa.exception.RfcInvalidStatusException;
 import dsd.api.cdmsa.exception.RfcNotFoundException;
-import dsd.api.cdmsa.model.ADR;
-import dsd.api.cdmsa.model.Alternative;
-import dsd.api.cdmsa.model.RFC;
-import dsd.api.cdmsa.repository.AlternativeRepository;
-import dsd.api.cdmsa.repository.CommentRepository;
-import dsd.api.cdmsa.repository.OrganizationRepository;
-import dsd.api.cdmsa.repository.RfcRepository;
-import dsd.api.cdmsa.repository.TemplateRepository;
-import dsd.api.cdmsa.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -44,6 +32,7 @@ public class RfcService {
     private final OrganizationRepository organizationRepository;
     private final AlternativeRepository alternativeRepository;
     private final CommentRepository commentRepository;
+    private final VoteRepository voteRepository;
 
     private final AdrService adrService;
 
@@ -168,34 +157,39 @@ public class RfcService {
     }
 
     private RfcResponse toDetailedResponse(RFC rfc) {
-    List<AlternativeResponse> alts = alternativeRepository.findByRfcId(rfc.getId()).stream()
-        .map(AlternativeResponse::fromEntity)
-        .collect(Collectors.toList());
 
-    List<CommentResponse> comments = commentRepository.findByRfcId(rfc.getId()).stream()
-        .map(c -> new CommentResponse(
-            c.getId(),
-            c.getAuthor() != null ? c.getAuthor().getId() : null,
-            c.getAuthor() != null ? c.getAuthor().getUsername() : null,
-            c.getContent(),
-            c.getCreatedAt(),
-            c.getUpdatedAt()
-        ))
-        .collect(Collectors.toList());
+        List<AlternativeResponse> alts = alternativeRepository.findByRfcId(rfc.getId()).stream()
+                .map(alt -> {
+                    int yesCount = voteRepository.countByAlternativeAndOutcome(alt, true);
+                    int noCount = voteRepository.countByAlternativeAndOutcome(alt, false);
+                    return AlternativeResponse.fromEntityVotes(alt, yesCount, noCount);
+                })
+                .collect(Collectors.toList());
 
-    return new RfcResponse(
-        rfc.getId(),
-        rfc.getTitle(),
-        rfc.getDescription(),
-        rfc.getUser() != null ? rfc.getUser().getId() : null,
-        rfc.getUser() != null ? rfc.getUser().getName() : null,
-        rfc.getTemplate() != null ? rfc.getTemplate().getId() : null,
-        rfc.getOrg() != null ? rfc.getOrg().getId() : null,
-        rfc.getStatus(),
-        rfc.getCreatedAt(),
-        rfc.getUpdatedAt(),
-        alts,
-        comments);
+        List<CommentResponse> comments = commentRepository.findByRfcId(rfc.getId()).stream()
+            .map(c -> new CommentResponse(
+                c.getId(),
+                c.getAuthor() != null ? c.getAuthor().getId() : null,
+                c.getAuthor() != null ? c.getAuthor().getUsername() : null,
+                c.getContent(),
+                c.getCreatedAt(),
+                c.getUpdatedAt()
+            ))
+            .collect(Collectors.toList());
+
+        return new RfcResponse(
+            rfc.getId(),
+            rfc.getTitle(),
+            rfc.getDescription(),
+            rfc.getUser() != null ? rfc.getUser().getId() : null,
+            rfc.getUser() != null ? rfc.getUser().getName() : null,
+            rfc.getTemplate() != null ? rfc.getTemplate().getId() : null,
+            rfc.getOrg() != null ? rfc.getOrg().getId() : null,
+            rfc.getStatus(),
+            rfc.getCreatedAt(),
+            rfc.getUpdatedAt(),
+            alts,
+            comments);
     }
 
     // ---------- Alternatives (POST & GET) ----------
@@ -278,8 +272,12 @@ public class RfcService {
         }
 
         return alternativeRepository.findByRfcId(rfcId).stream()
-                .map(AlternativeResponse::fromEntity)
-                .toList();
+                .map(alt -> {
+                    int yesCount = voteRepository.countByAlternativeAndOutcome(alt, true);
+                    int noCount = voteRepository.countByAlternativeAndOutcome(alt, false);
+                    return AlternativeResponse.fromEntityVotes(alt, yesCount, noCount);
+                })
+                .collect(Collectors.toList());
     }
 
     @Transactional
@@ -321,6 +319,49 @@ public class RfcService {
 
         RFC saved = rfcRepository.save(rfc);
         return toResponse(saved);
+    }
+
+    @Transactional
+    public VoteResponse voteForAlternative(Long altId, Long userId, boolean outcome) {
+        Alternative alternative = alternativeRepository.findById(altId)
+                .orElseThrow(() -> new EntityNotFoundException("Alternative not found"));
+
+        User voter = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+
+        Optional<Vote> existing = voteRepository.findByAlternativeAndVoter(alternative, voter);
+
+
+        if (existing.isPresent()) {
+            Vote vote = existing.get();
+
+            // delete vote if u click on the same thumb
+            if (vote.getOutcome() != null && vote.getOutcome().equals(outcome)) {
+                voteRepository.delete(vote);
+                int yesCount = voteRepository.countByAlternativeAndOutcome(alternative, true);
+                int noCount = voteRepository.countByAlternativeAndOutcome(alternative, false);
+
+                return new VoteResponse(yesCount, noCount);
+            }
+
+            // change vote instead
+            vote.setOutcome(outcome);
+            voteRepository.save(vote);
+            int yesCount = voteRepository.countByAlternativeAndOutcome(alternative, true);
+            int noCount = voteRepository.countByAlternativeAndOutcome(alternative, false);
+
+            return new VoteResponse(yesCount, noCount);
+        }
+
+        // no existing vote
+        Vote newVote = new Vote();
+        newVote.setAlternative(alternative);
+        newVote.setVoter(voter);
+        newVote.setOutcome(outcome);
+        voteRepository.save(newVote);
+        int yesCount = voteRepository.countByAlternativeAndOutcome(alternative, true);
+        int noCount = voteRepository.countByAlternativeAndOutcome(alternative, false);
+        return new VoteResponse(yesCount, noCount);
     }
 
 }


### PR DESCRIPTION
Implementation of backend endpoints to allow Reviewers to vote for a certain alternative. Votes  are recorded in a dedicated table, allowing also changing (or retracting) votes. The total vote count per alternative can be retrievable for display in the UI.