### PR TITLE
GitHub config + adr push

### DIFF
--- a/src/main/java/dsd/api/cdmsa/controller/AdrController.java
+++ b/src/main/java/dsd/api/cdmsa/controller/AdrController.java
@@ -2,6 +2,7 @@ package dsd.api.cdmsa.controller;
 
 import dsd.api.cdmsa.dto.AdrResponse;
 import dsd.api.cdmsa.dto.CreateAdrRequest;
+import dsd.api.cdmsa.dto.PublishAdrRequest;
 import dsd.api.cdmsa.service.AdrService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -44,10 +45,9 @@ public class AdrController {
         // TO DO - check if user is logged in ...
         Long userId = getCurrentUserId(httpRequest);
 
-        // build the markdown file from form, push it on GitHub through API, store it in the db (the url)
         AdrResponse response = adrService.createAdr(request, userId);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.ok(response);
     }
 
 
@@ -76,6 +76,17 @@ public class AdrController {
     public Page<AdrResponse> listAdrs(
             @PageableDefault(size = 20) Pageable pageable) {
         return adrService.listAdrs(pageable);
+    }
+
+    @PostMapping("/publish")
+    public ResponseEntity<AdrResponse> publishAdr(@Valid @RequestBody PublishAdrRequest request, HttpServletRequest httpRequest) {
+        // TO DO - check if user is logged in ...
+        Long userId = getCurrentUserId(httpRequest);
+
+        // build the markdown file from form, push it on GitHub through API, store it in the db (the url)
+        AdrResponse response = adrService.publishAdr(request, userId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     /* it is necessary?

--- a/src/main/java/dsd/api/cdmsa/controller/AdrController.java
+++ b/src/main/java/dsd/api/cdmsa/controller/AdrController.java
@@ -44,9 +44,9 @@ public class AdrController {
         // TO DO - check if user is logged in ...
         Long userId = getCurrentUserId(httpRequest);
 
-        AdrResponse response = adrService.createAdr(request);
         // build the markdown file from form, push it on GitHub through API, store it in the db (the url)
-        // ...
+        AdrResponse response = adrService.createAdr(request, userId);
+
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
@@ -67,7 +67,7 @@ public class AdrController {
                                                  @Valid @RequestBody dsd.api.cdmsa.dto.UpdateAdrRequest request,
                                                  HttpServletRequest httpRequest) {
         Long userId = getCurrentUserId(httpRequest);
-        AdrResponse response = adrService.updateAdr(id, request);
+        AdrResponse response = adrService.updateAdr(id, request, userId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/dsd/api/cdmsa/controller/OrganizationController.java
+++ b/src/main/java/dsd/api/cdmsa/controller/OrganizationController.java
@@ -1,13 +1,14 @@
 package dsd.api.cdmsa.controller;
 
-import dsd.api.cdmsa.dto.OrganizationResponse;
-import dsd.api.cdmsa.dto.UpdateOrganizationRequest;
+import dsd.api.cdmsa.dto.*;
 import dsd.api.cdmsa.service.OrganizationService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @CrossOrigin(origins = "*")
@@ -48,5 +49,42 @@ public class OrganizationController {
         Long userId = getCurrentUserId(httpRequest);
         OrganizationResponse orgUpdated = orgService.updateOrgDetails(userId, request);
         return ResponseEntity.ok(orgUpdated);
+    }
+
+    // connect GitHub through pat
+    @PostMapping("/github")
+    public ResponseEntity<ConnectGitHubResponse> connectGitHub(@Valid @RequestBody ConnectGitHubRequest request, HttpServletRequest httpRequest){
+        // check id user is admin
+        Long userId = getCurrentUserId(httpRequest);
+        ConnectGitHubResponse resp = orgService.connectGitHub(userId, request);
+        return ResponseEntity.ok(resp);
+    }
+
+    // get the repos of the organization, to show them in a dropdown menu and select one
+    @GetMapping("/github/repos")
+    public ResponseEntity<List<RepositoryResponse>> getRepos(HttpServletRequest httpRequest) {
+        Long userId = getCurrentUserId(httpRequest);
+        return ResponseEntity.ok(orgService.getRepos(userId));
+    }
+
+    // get the branches of a certain repo of the organization, to show them in a dropdown menu and select one
+    // check if passing owner is necessary, we have only one owner?
+    @GetMapping("/github/{owner}/{repo}/branches") // owner and repo sent from the frontend, we have them from getRepos
+    public ResponseEntity<List<BranchResponse>> getBranches(@PathVariable String owner,
+                                                            @PathVariable String repo,
+                                                            HttpServletRequest httpRequest) {
+        Long userId = getCurrentUserId(httpRequest);
+        return ResponseEntity.ok(orgService.getBranches(userId, owner, repo));
+    }
+
+    // choose repo e branch where to store ADRs
+    @PutMapping("/github/selection")
+    public ResponseEntity<OrganizationResponse> saveRepoBranchSelection(
+            @Valid @RequestBody RepoBranchSelectionRequest request,
+            HttpServletRequest httpRequest) {
+
+        Long userId = getCurrentUserId(httpRequest);
+        OrganizationResponse response = orgService.saveRepoBranchSelection(userId, request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/dsd/api/cdmsa/dto/AdrResponse.java
+++ b/src/main/java/dsd/api/cdmsa/dto/AdrResponse.java
@@ -11,5 +11,6 @@ public record AdrResponse(
         ADR.Status status,
         Long rfcId,
         java.time.Instant createdAt,
-        java.time.Instant updatedAt) {
+        java.time.Instant updatedAt,
+        String gitHubUrl) {
 }

--- a/src/main/java/dsd/api/cdmsa/dto/BranchResponse.java
+++ b/src/main/java/dsd/api/cdmsa/dto/BranchResponse.java
@@ -1,0 +1,5 @@
+package dsd.api.cdmsa.dto;
+
+public record BranchResponse(
+        String name
+) {}

--- a/src/main/java/dsd/api/cdmsa/dto/ConnectGitHubRequest.java
+++ b/src/main/java/dsd/api/cdmsa/dto/ConnectGitHubRequest.java
@@ -1,0 +1,7 @@
+package dsd.api.cdmsa.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ConnectGitHubRequest(
+        @NotBlank String pat
+) {}

--- a/src/main/java/dsd/api/cdmsa/dto/ConnectGitHubResponse.java
+++ b/src/main/java/dsd/api/cdmsa/dto/ConnectGitHubResponse.java
@@ -1,0 +1,6 @@
+package dsd.api.cdmsa.dto;
+
+public record ConnectGitHubResponse(
+        String githubLogin,
+        String githubName
+) {}

--- a/src/main/java/dsd/api/cdmsa/dto/OrganizationResponse.java
+++ b/src/main/java/dsd/api/cdmsa/dto/OrganizationResponse.java
@@ -3,7 +3,9 @@ package dsd.api.cdmsa.dto;
 public record OrganizationResponse(
         String companyName,
         String description,
-        String domain //,
-        // String gitHubToken
+        String domain,
+        String selectedRepoName,
+        String selectedBranchName,
+        String repoOwner
         ) {
 }

--- a/src/main/java/dsd/api/cdmsa/dto/PublishAdrRequest.java
+++ b/src/main/java/dsd/api/cdmsa/dto/PublishAdrRequest.java
@@ -1,0 +1,7 @@
+package dsd.api.cdmsa.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PublishAdrRequest(
+        @NotNull Long adrId) {
+}

--- a/src/main/java/dsd/api/cdmsa/dto/RepoBranchSelectionRequest.java
+++ b/src/main/java/dsd/api/cdmsa/dto/RepoBranchSelectionRequest.java
@@ -1,0 +1,8 @@
+package dsd.api.cdmsa.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RepoBranchSelectionRequest(
+        @NotBlank String repoName,
+        @NotBlank String branchName
+) {}

--- a/src/main/java/dsd/api/cdmsa/dto/RepositoryResponse.java
+++ b/src/main/java/dsd/api/cdmsa/dto/RepositoryResponse.java
@@ -1,0 +1,6 @@
+package dsd.api.cdmsa.dto;
+
+public record RepositoryResponse(
+        String name,
+        String owner
+) {}

--- a/src/main/java/dsd/api/cdmsa/dto/UpdateOrganizationRequest.java
+++ b/src/main/java/dsd/api/cdmsa/dto/UpdateOrganizationRequest.java
@@ -5,7 +5,8 @@ import jakarta.validation.constraints.NotBlank;
 public record UpdateOrganizationRequest(
         @NotBlank String companyName,
         @NotBlank String description,
-        @NotBlank String domain //,
-        //String gitHubToken
+        @NotBlank String domain,
+        String selectedRepoName,
+        String selectedBranchName
         ) {
 }

--- a/src/main/java/dsd/api/cdmsa/model/ADR.java
+++ b/src/main/java/dsd/api/cdmsa/model/ADR.java
@@ -32,6 +32,9 @@ public class ADR {
     @Column(length = 4000)
     private String consequences;
 
+    @Column(length = 4000)
+    private String gitHubUrl;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)
     private Status status = Status.DRAFT;

--- a/src/main/java/dsd/api/cdmsa/model/Organization.java
+++ b/src/main/java/dsd/api/cdmsa/model/Organization.java
@@ -30,6 +30,18 @@ public class Organization {
     @Column
     private String description;
 
+    @Column
+    private String gitHubToken;
+
+    @Column
+    private String selectedRepoName;
+
+    @Column
+    private String selectedBranchName;
+
+    @Column
+    private String repoOwner;
+
     @OneToOne
     @JsonIgnoreProperties({"org"})
     @JoinColumn(name = "admin_user_id", unique = true)

--- a/src/main/java/dsd/api/cdmsa/service/AdrService.java
+++ b/src/main/java/dsd/api/cdmsa/service/AdrService.java
@@ -256,7 +256,8 @@ public class AdrService {
         String repoName = org.getSelectedRepoName();
         String branchName = org.getSelectedBranchName();
 
-        String url = "https://api.github.com/repos/" + repoOwner + "/" + repoName + "/contents/" + filePath;
+        String url = "https://api.github.com/repos/" + repoOwner + "/" + repoName + "/contents/" + filePath + "?ref=" + branchName;
+
 
         String sha = getFileSha(url, token);
         if (sha == null) {
@@ -300,7 +301,7 @@ public class AdrService {
     private String getFileSha(String url, String token) throws Exception {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + token);
-        headers.set("Accept", "application/vnd.github+json");
+        headers.set("Accept", "application/vnd.github.v3+json");
 
         HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
 

--- a/src/main/java/dsd/api/cdmsa/service/AdrService.java
+++ b/src/main/java/dsd/api/cdmsa/service/AdrService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dsd.api.cdmsa.dto.AdrResponse;
 import dsd.api.cdmsa.dto.CreateAdrRequest;
+import dsd.api.cdmsa.dto.PublishAdrRequest;
 import dsd.api.cdmsa.dto.UpdateAdrRequest;
 import dsd.api.cdmsa.model.*;
 import dsd.api.cdmsa.repository.AdrRepository;
@@ -16,7 +17,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.StandardCharsets;
@@ -41,19 +41,17 @@ public class AdrService {
         RFC rfc = rfcRepository.findById(request.rfcId())
                 .orElseThrow(() -> new EntityNotFoundException("RFC not found with id " + request.rfcId()));
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found"));
-        Organization org = user.getOrg();
 
         ADR adr = new ADR();
         adr.setTitle(request.title().trim());
         adr.setContext(request.context().trim());
         adr.setDecision(request.decision().trim());
-        adr.setConsequences(request.consequences().trim());				// from this create markdown file, generate and store the url of GitHub in the db
+        adr.setConsequences(request.consequences().trim());
         adr.setStatus(request.status());
         adr.setRfc(rfc);
         ADR saved = adrRepository.save(adr);
 
+        /*
         String markdown = buildMarkdown(saved);
 
         // push the markdown on github
@@ -68,7 +66,7 @@ public class AdrService {
         // save url in the db
         saved.setGitHubUrl(githubUrl);
         saved = adrRepository.save(saved);
-
+        */
 
         return new AdrResponse(
                 saved.getId(),
@@ -80,7 +78,7 @@ public class AdrService {
                 saved.getRfc().getId(),
                 saved.getCreatedAt(),
                 saved.getUpdatedAt(),
-                saved.getGitHubUrl()
+                saved.getGitHubUrl()        // null here
         );
     }
 
@@ -100,7 +98,7 @@ public class AdrService {
                 adr.getRfc().getId(),
                 adr.getCreatedAt(),
                 adr.getUpdatedAt(),
-                adr.getGitHubUrl()
+                adr.getGitHubUrl()          // null until i approve the adr
         );
     }
 
@@ -147,6 +145,7 @@ public class AdrService {
 
         ADR saved = adrRepository.save(adr);
 
+        /*
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("User not found"));
         Organization org = user.getOrg();
@@ -160,6 +159,8 @@ public class AdrService {
             throw new RuntimeException("Failed to update ADR on GitHub", e);
         }
 
+         */
+
         return new AdrResponse(
                 saved.getId(),
                 saved.getTitle(),
@@ -171,6 +172,44 @@ public class AdrService {
                 saved.getCreatedAt(),
                 saved.getUpdatedAt(),
                 saved.getGitHubUrl()
+        );
+    }
+
+    public AdrResponse publishAdr(PublishAdrRequest request, Long userId){
+        ADR adr = adrRepository.findById(request.adrId())
+                .orElseThrow(() -> new EntityNotFoundException("ADR not found with id " + request.adrId()));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+        Organization org = user.getOrg();
+
+        String markdown = buildMarkdown(adr);
+
+        // push the markdown on github
+        String filePath = "adr-" + adr.getId() + ".md";
+        String githubUrl;
+        try {
+            githubUrl = pushMarkdownToGitHub(markdown, filePath, org, adr.getTitle());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to push ADR to GitHub", e);
+        }
+
+        // save url in the db
+        adr.setGitHubUrl(githubUrl);
+        adr = adrRepository.save(adr);
+
+
+        return new AdrResponse(
+                adr.getId(),
+                adr.getTitle(),
+                adr.getContext(),
+                adr.getDecision(),
+                adr.getConsequences(),
+                adr.getStatus(),
+                adr.getRfc().getId(),
+                adr.getCreatedAt(),
+                adr.getUpdatedAt(),
+                adr.getGitHubUrl()
         );
     }
 
@@ -226,7 +265,7 @@ public class AdrService {
 
         HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
 
-        // Effettua la richiesta PUT
+        // do the put
         RestTemplate restTemplate = new RestTemplate();
         ResponseEntity<String> response = restTemplate.exchange(
                 url,
@@ -240,13 +279,13 @@ public class AdrService {
                     + " - " + response.getBody());
         }
 
-        // Parsing della risposta
+        // Parsing
         JsonNode rootNode = objectMapper.readTree(response.getBody());
         return rootNode.get("content").get("html_url").asText();
 
     }
 
-
+    /*
     // update a .md file already existing
     private void updateMarkdownOnGitHub(String markdownContent, String filePath,
                                         Organization org, String title) throws Exception {
@@ -258,7 +297,7 @@ public class AdrService {
 
         String url = "https://api.github.com/repos/" + repoOwner + "/" + repoName + "/contents/" + filePath + "?ref=" + branchName;
 
-
+        // check the sha
         String sha = getFileSha(url, token);
         if (sha == null) {
             throw new RuntimeException("Cannot update file: file not found on GitHub");
@@ -267,14 +306,14 @@ public class AdrService {
         String contentBase64 = Base64.getEncoder().encodeToString(
                 markdownContent.getBytes(StandardCharsets.UTF_8));
 
-        // Crea il body della richiesta
+        // request body
         Map<String, String> requestBody = new HashMap<>();
         requestBody.put("message", "Updated ADR - " + title);
         requestBody.put("content", contentBase64);
         requestBody.put("sha", sha);
         requestBody.put("branch", branchName);
 
-        // Configura gli headers
+        // headers
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + token);
         headers.set("Accept", "application/vnd.github.v3+json");
@@ -282,7 +321,7 @@ public class AdrService {
 
         HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
 
-        // Effettua la richiesta PUT
+        // do the put
         RestTemplate restTemplate = new RestTemplate();
         ResponseEntity<String> response = restTemplate.exchange(
                 url,
@@ -305,7 +344,7 @@ public class AdrService {
 
         HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
 
-        // Effettua la richiesta GET
+        // do the get
         RestTemplate restTemplate = new RestTemplate();
 
         try {
@@ -329,5 +368,7 @@ public class AdrService {
 
         return null;
     }
+
+     */
 }
 

--- a/src/main/java/dsd/api/cdmsa/service/AdrService.java
+++ b/src/main/java/dsd/api/cdmsa/service/AdrService.java
@@ -1,19 +1,28 @@
 package dsd.api.cdmsa.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dsd.api.cdmsa.dto.AdrResponse;
 import dsd.api.cdmsa.dto.CreateAdrRequest;
 import dsd.api.cdmsa.dto.UpdateAdrRequest;
-import dsd.api.cdmsa.model.ADR;
-import dsd.api.cdmsa.model.RFC;
-import dsd.api.cdmsa.model.Alternative;
+import dsd.api.cdmsa.model.*;
 import dsd.api.cdmsa.repository.AdrRepository;
 import dsd.api.cdmsa.repository.RfcRepository;
+import dsd.api.cdmsa.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
 
 
 @Service
@@ -22,13 +31,19 @@ public class AdrService {
 
     private final AdrRepository adrRepository;
     private final RfcRepository rfcRepository;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
 
     @Transactional
-    public AdrResponse createAdr(CreateAdrRequest request) {
+    public AdrResponse createAdr(CreateAdrRequest request, Long userId) {
         // eventually put some checks on the request (but we used @Valid so maybe not needed) ...
 
         RFC rfc = rfcRepository.findById(request.rfcId())
                 .orElseThrow(() -> new EntityNotFoundException("RFC not found with id " + request.rfcId()));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        Organization org = user.getOrg();
 
         ADR adr = new ADR();
         adr.setTitle(request.title().trim());
@@ -39,6 +54,22 @@ public class AdrService {
         adr.setRfc(rfc);
         ADR saved = adrRepository.save(adr);
 
+        String markdown = buildMarkdown(saved);
+
+        // push the markdown on github
+        String filePath = "adr-" + saved.getId() + ".md";
+        String githubUrl;
+        try {
+            githubUrl = pushMarkdownToGitHub(markdown, filePath, org, saved.getTitle());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to push ADR to GitHub", e);
+        }
+
+        // save url in the db
+        saved.setGitHubUrl(githubUrl);
+        saved = adrRepository.save(saved);
+
+
         return new AdrResponse(
                 saved.getId(),
                 saved.getTitle(),
@@ -48,7 +79,8 @@ public class AdrService {
                 saved.getStatus(),
                 saved.getRfc().getId(),
                 saved.getCreatedAt(),
-                saved.getUpdatedAt()
+                saved.getUpdatedAt(),
+                saved.getGitHubUrl()
         );
     }
 
@@ -67,7 +99,8 @@ public class AdrService {
                 adr.getStatus(),
                 adr.getRfc().getId(),
                 adr.getCreatedAt(),
-                adr.getUpdatedAt()
+                adr.getUpdatedAt(),
+                adr.getGitHubUrl()
         );
     }
 
@@ -84,7 +117,8 @@ public class AdrService {
                         adr.getStatus(),
                         adr.getRfc().getId(),
                         adr.getCreatedAt(),
-                        adr.getUpdatedAt()
+                        adr.getUpdatedAt(),
+                        adr.getGitHubUrl()
                 ));
     }
 
@@ -101,7 +135,7 @@ public class AdrService {
     }
 
     @Transactional
-    public AdrResponse updateAdr(Long id, UpdateAdrRequest request) {
+    public AdrResponse updateAdr(Long id, UpdateAdrRequest request, Long userId) {
         ADR adr = adrRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("ADR not found with id " + id));
 
@@ -113,6 +147,19 @@ public class AdrService {
 
         ADR saved = adrRepository.save(adr);
 
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+        Organization org = user.getOrg();
+
+        String markdown = buildMarkdown(saved);
+        String filePath = "adr-" + saved.getId() + ".md";
+
+        try {
+            updateMarkdownOnGitHub(markdown, filePath, org, saved.getTitle());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to update ADR on GitHub", e);
+        }
+
         return new AdrResponse(
                 saved.getId(),
                 saved.getTitle(),
@@ -122,8 +169,164 @@ public class AdrService {
                 saved.getStatus(),
                 saved.getRfc().getId(),
                 saved.getCreatedAt(),
-                saved.getUpdatedAt()
+                saved.getUpdatedAt(),
+                saved.getGitHubUrl()
         );
+    }
+
+
+    // GITHUB RELATED METHODS
+    public String buildMarkdown(ADR adr) {
+        return """
+    # %s
+
+    ## Context
+    %s
+
+    ## Decision
+    %s
+
+    ## Consequences
+    %s
+
+    ## Status
+    %s
+    """.formatted(
+                adr.getTitle(),
+                adr.getContext(),
+                adr.getDecision(),
+                adr.getConsequences(),
+                adr.getStatus()
+        );
+    }
+
+    // push on GitHub
+    private String pushMarkdownToGitHub(String markdownContent, String filePath, Organization org, String title) throws Exception {
+        // get this from org
+        String token = org.getGitHubToken();
+        String repoOwner = org.getRepoOwner();
+        String repoName = org.getSelectedRepoName();
+        String branchName = org.getSelectedBranchName();
+
+        String url = "https://api.github.com/repos/" + repoOwner + "/" + repoName + "/contents/" + filePath;
+        String contentBase64 = Base64.getEncoder().encodeToString(
+                markdownContent.getBytes(StandardCharsets.UTF_8));
+
+        // Crea il body della richiesta
+        Map<String, String> requestBody = new HashMap<>();
+        requestBody.put("message", "Published ADR - " + title);
+        requestBody.put("content", contentBase64);
+        requestBody.put("branch", branchName);
+
+        // Configura gli headers
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + token);
+        headers.set("Accept", "application/vnd.github.v3+json");
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
+
+        // Effettua la richiesta PUT
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(
+                url,
+                HttpMethod.PUT,
+                requestEntity,
+                String.class
+        );
+
+        if (response.getStatusCode().value() >= 400) {
+            throw new RuntimeException("GitHub API error: " + response.getStatusCode()
+                    + " - " + response.getBody());
+        }
+
+        // Parsing della risposta
+        JsonNode rootNode = objectMapper.readTree(response.getBody());
+        return rootNode.get("content").get("html_url").asText();
+
+    }
+
+
+    // update a .md file already existing
+    private void updateMarkdownOnGitHub(String markdownContent, String filePath,
+                                        Organization org, String title) throws Exception {
+        // get this from org
+        String token = org.getGitHubToken();
+        String repoOwner = org.getRepoOwner();
+        String repoName = org.getSelectedRepoName();
+        String branchName = org.getSelectedBranchName();
+
+        String url = "https://api.github.com/repos/" + repoOwner + "/" + repoName + "/contents/" + filePath;
+
+        String sha = getFileSha(url, token);
+        if (sha == null) {
+            throw new RuntimeException("Cannot update file: file not found on GitHub");
+        }
+
+        String contentBase64 = Base64.getEncoder().encodeToString(
+                markdownContent.getBytes(StandardCharsets.UTF_8));
+
+        // Crea il body della richiesta
+        Map<String, String> requestBody = new HashMap<>();
+        requestBody.put("message", "Updated ADR - " + title);
+        requestBody.put("content", contentBase64);
+        requestBody.put("sha", sha);
+        requestBody.put("branch", branchName);
+
+        // Configura gli headers
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + token);
+        headers.set("Accept", "application/vnd.github.v3+json");
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
+
+        // Effettua la richiesta PUT
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(
+                url,
+                HttpMethod.PUT,
+                requestEntity,
+                String.class
+        );
+
+        if (response.getStatusCode().value() >= 400) {
+            throw new RuntimeException("GitHub API error: " + response.getStatusCode()
+                    + " - " + response.getBody());
+        }
+
+    }
+
+    private String getFileSha(String url, String token) throws Exception {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + token);
+        headers.set("Accept", "application/vnd.github+json");
+
+        HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
+
+        // Effettua la richiesta GET
+        RestTemplate restTemplate = new RestTemplate();
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    requestEntity,
+                    String.class
+            );
+
+            if (response.getStatusCode().value() == 200) {
+                JsonNode rootNode = objectMapper.readTree(response.getBody());
+                return rootNode.get("sha").asText();
+            }
+        } catch (HttpClientErrorException e) {
+            if (e.getStatusCode().value() == 404) {
+                return null;
+            }
+            throw e;
+        }
+
+        return null;
     }
 }
 

--- a/src/main/java/dsd/api/cdmsa/service/OrganizationService.java
+++ b/src/main/java/dsd/api/cdmsa/service/OrganizationService.java
@@ -1,14 +1,22 @@
 package dsd.api.cdmsa.service;
 
-import dsd.api.cdmsa.dto.OrganizationResponse;
-import dsd.api.cdmsa.dto.UpdateOrganizationRequest;
+import com.fasterxml.jackson.databind.JsonNode;
+import dsd.api.cdmsa.dto.*;
 import dsd.api.cdmsa.model.Organization;
 import dsd.api.cdmsa.model.User;
 import dsd.api.cdmsa.repository.OrganizationRepository;
 import dsd.api.cdmsa.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,10 +31,15 @@ public class OrganizationService {
         User user = userRepo.findById(id)
                 .orElseThrow(() -> new RuntimeException("User not found"));
         Organization org = user.getOrg();
+
+        // when github is not connected yet, the last three are null and so not displayed in the UI
         return new OrganizationResponse(
                 org.getName(),
                 org.getDescription(),
-                org.getDomain()
+                org.getDomain(),
+                org.getSelectedRepoName(),
+                org.getSelectedBranchName(),
+                org.getRepoOwner()
         );
     }
 
@@ -40,13 +53,130 @@ public class OrganizationService {
         org.setName(request.companyName().trim());
         org.setDescription(request.description().trim());
         org.setDomain(request.domain().trim());
-        // org.setGitHubToken(request.gitHubToken().trim());
+        org.setSelectedRepoName(request.selectedRepoName() != null ? request.selectedRepoName().trim() : null);
+        org.setSelectedBranchName(request.selectedBranchName() != null ? request.selectedBranchName().trim() : null);
 
         Organization updatedOrg = orgRepo.save(org);
         return new OrganizationResponse(
                 updatedOrg.getName(),
                 updatedOrg.getDescription(),
-                updatedOrg.getDomain()
+                updatedOrg.getDomain(),
+                updatedOrg.getSelectedRepoName(),
+                updatedOrg.getSelectedBranchName(),
+                updatedOrg.getRepoOwner()
+        );
+    }
+
+    @Transactional
+    public ConnectGitHubResponse connectGitHub (Long userId, ConnectGitHubRequest request){
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        Organization org = user.getOrg();
+
+        String pat = request.pat().trim();
+
+        // call github API to retrieve the user (organization) account from the pat
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + pat);
+        headers.set("Accept", "application/vnd.github.v3+json");
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        ResponseEntity<JsonNode> response;
+        try {
+            response = restTemplate.exchange(
+                    "https://api.github.com/user",
+                    HttpMethod.GET,
+                    entity,
+                    JsonNode.class
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Invalid PAT or unable to contact GitHub");
+        }
+
+        JsonNode body = response.getBody();
+        String githubLogin = body.get("login").asText();
+        // name probably not necessary
+        String githubName = body.has("name") && !body.get("name").isNull() ? body.get("name").asText() : githubLogin;
+
+        // TODO: encrypt PAT before storing
+        org.setGitHubToken(pat);
+        org.setRepoOwner(githubLogin);
+        orgRepo.save(org);
+
+        return new ConnectGitHubResponse(githubLogin, githubName);
+    }
+
+    @Transactional(readOnly = true)
+    public List<RepositoryResponse> getRepos(Long userId) {
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        Organization org = user.getOrg();
+
+        String pat = org.getGitHubToken();
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + pat);
+        headers.set("Accept", "application/vnd.github.v3+json");
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<JsonNode[]> response = restTemplate.exchange(
+                "https://api.github.com/user/repos",
+                HttpMethod.GET,
+                entity,
+                JsonNode[].class
+        );
+
+        return Arrays.stream(response.getBody())
+                .map(repo -> new RepositoryResponse(repo.get("name").asText(),
+                        repo.get("owner").get("login").asText()))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<BranchResponse> getBranches(Long userId, String owner, String repo) {
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        Organization org = user.getOrg();
+        String pat = org.getGitHubToken();
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + pat);
+        headers.set("Accept", "application/vnd.github.v3+json");
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<JsonNode[]> response = restTemplate.exchange(
+                "https://api.github.com/repos/" + owner + "/" + repo + "/branches",
+                HttpMethod.GET,
+                entity,
+                JsonNode[].class
+        );
+
+        return Arrays.stream(response.getBody())
+                .map(b -> new BranchResponse(b.get("name").asText()))
+                .toList();
+    }
+
+    @Transactional
+    public OrganizationResponse saveRepoBranchSelection(Long userId, RepoBranchSelectionRequest request) {
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        Organization org = user.getOrg();
+
+        org.setSelectedRepoName(request.repoName().trim());
+        org.setSelectedBranchName(request.branchName().trim());
+
+        orgRepo.save(org);
+
+        return new OrganizationResponse(
+                org.getName(),
+                org.getDescription(),
+                org.getDomain(),
+                org.getSelectedRepoName(),
+                org.getSelectedBranchName(),
+                org.getRepoOwner()
         );
     }
 }


### PR DESCRIPTION
Implementation of the backend logic to allow Organization Admins to connect GitHub (through PAT), select a target repository and branch, and store these settings securely for use by the ADR publishing service.

Implementation of the backend functionality to create a Markdown representation of an approved ADR and push it to the organization’s configured GitHub repository.