### PR TITLE
Search bar with filters and deletion of draft adr

### DIFF
--- a/src/main/java/dsd/api/cdmsa/config/ConfigIndexes.java
+++ b/src/main/java/dsd/api/cdmsa/config/ConfigIndexes.java
@@ -1,0 +1,60 @@
+package dsd.api.cdmsa.config;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class ConfigIndexes implements CommandLineRunner {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public ConfigIndexes(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+
+        // Index for the search, on table RFC
+        // on title and description
+        recreateIndex("rfc", "ft_idx_rfc_combined", "title, description");
+
+        // Index for the search, on table ADR
+        // on title, context and decision
+        recreateIndex("adrs", "ft_idx_adr_combined", "title, context, decision");
+    }
+
+    private void recreateIndex(String tableName, String indexName, String columns) {
+        try {
+            // Check if index exists already
+            Integer count = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(1) FROM information_schema.statistics " +
+                            "WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?",
+                    Integer.class, tableName, indexName
+            );
+
+            // If it exists, we delete to update every time
+            if (count != null && count > 0) {
+                System.out.println("Index doesn't exist '" + indexName + "' on " + tableName + ". Regenerating...");
+                try {
+                    jdbcTemplate.execute("ALTER TABLE " + tableName + " DROP INDEX " + indexName);
+                } catch (Exception e) {
+                    System.out.println();
+                }
+            }
+
+            // Creating the correct indexes
+            System.out.println("Creating index Full-Text '" + indexName + "' on " + tableName + " (" + columns + ")...");
+
+            jdbcTemplate.execute("ALTER TABLE " + tableName + " ADD FULLTEXT INDEX " + indexName + " (" + columns + ")");
+
+            System.out.println("Index '" + indexName + "' created/updated with success");
+
+        } catch (Exception e) {
+            System.err.println("Impossible configure index on '" + tableName + "'. Motivation: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/dsd/api/cdmsa/controller/AdrController.java
+++ b/src/main/java/dsd/api/cdmsa/controller/AdrController.java
@@ -114,6 +114,17 @@ public class AdrController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteAdr(
+            @PathVariable Long id,
+            HttpServletRequest httpRequest) {
+
+        Long userId = getCurrentUserId(httpRequest);
+        Long orgId = getCurrentUserOrgId(httpRequest);
+        adrService.deleteAdr(id, orgId, userId);
+        return ResponseEntity.noContent().build();
+    }
+
     /* it is necessary?
 
     public ADR createDraftFromRfcAndAlternative(RFC rfc, Alternative alternative) {

--- a/src/main/java/dsd/api/cdmsa/controller/SearchController.java
+++ b/src/main/java/dsd/api/cdmsa/controller/SearchController.java
@@ -2,29 +2,42 @@ package dsd.api.cdmsa.controller;
 
 import dsd.api.cdmsa.dto.SearchResult;
 import dsd.api.cdmsa.service.SearchService;
+import dsd.api.cdmsa.exception.OrgNotFoundException;
+import dsd.api.cdmsa.model.UserPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.time.Instant;
 import java.util.List;
 
 @RestController
-@RequestMapping("/search") // Endpoint base
+@RequestMapping("/search")
 @CrossOrigin(origins = "*")
 @RequiredArgsConstructor
 public class SearchController {
 
     private final SearchService service;
 
-    // GET /search?q=relational&sort=relevance
+    private Long getCurrentUserOrgId() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (principal instanceof UserPrincipal userPrincipal) {
+            Long orgId = userPrincipal.getOrgId();
+            if (orgId != null) return orgId;
+        }
+        throw new OrgNotFoundException(0L);
+    }
+
     @GetMapping
     public List<SearchResult> search(
             @RequestParam String q,
-            @RequestParam(defaultValue = "relevance") String sort, // values: relevance, date_asc, date_desc
+            @RequestParam(defaultValue = "relevance") String sort,
             @RequestParam(required = false) Long authorId,
-            @RequestParam(required = false) String dateFrom, // for example 2024-01-01
+            @RequestParam(required = false) String dateFrom,
             @RequestParam(required = false) String dateTo
     ) {
+        Long orgId = getCurrentUserOrgId();
+
         Instant from = null;
         Instant to = null;
         try {
@@ -33,6 +46,6 @@ public class SearchController {
         } catch (Exception e) {
         }
 
-        return service.search(q, sort, authorId, from, to);
+        return service.search(q, sort, authorId, orgId, from, to);
     }
 }

--- a/src/main/java/dsd/api/cdmsa/controller/SearchController.java
+++ b/src/main/java/dsd/api/cdmsa/controller/SearchController.java
@@ -1,0 +1,38 @@
+package dsd.api.cdmsa.controller;
+
+import dsd.api.cdmsa.dto.SearchResult;
+import dsd.api.cdmsa.service.SearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.util.List;
+
+@RestController
+@RequestMapping("/search") // Endpoint base
+@CrossOrigin(origins = "*")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService service;
+
+    // GET /search?q=relational&sort=relevance
+    @GetMapping
+    public List<SearchResult> search(
+            @RequestParam String q,
+            @RequestParam(defaultValue = "relevance") String sort, // values: relevance, date_asc, date_desc
+            @RequestParam(required = false) Long authorId,
+            @RequestParam(required = false) String dateFrom, // for example 2024-01-01
+            @RequestParam(required = false) String dateTo
+    ) {
+        Instant from = null;
+        Instant to = null;
+        try {
+            if (dateFrom != null) from = Instant.parse(dateFrom + "T00:00:00Z");
+            if (dateTo != null)   to   = Instant.parse(dateTo + "T23:59:59Z");
+        } catch (Exception e) {
+        }
+
+        return service.search(q, sort, authorId, from, to);
+    }
+}

--- a/src/main/java/dsd/api/cdmsa/dto/SearchResult.java
+++ b/src/main/java/dsd/api/cdmsa/dto/SearchResult.java
@@ -1,0 +1,16 @@
+package dsd.api.cdmsa.dto;
+
+import java.time.Instant;
+
+/**
+ * DTO immutabile da inviare al client.
+ */
+public record SearchResult(
+        Long id,
+        String title,
+        String snippet,
+        String authorName,
+        Instant date,
+        String type,
+        Double score
+) {}

--- a/src/main/java/dsd/api/cdmsa/dto/SearchResultProjection.java
+++ b/src/main/java/dsd/api/cdmsa/dto/SearchResultProjection.java
@@ -1,0 +1,17 @@
+package dsd.api.cdmsa.dto;
+
+import java.time.Instant;
+
+/**
+ * Interfaccia utilizzata da Spring Data JPA per mappare i risultati
+ * delle Native Query (SQL puro).
+ */
+public interface SearchResultProjection {
+    Long getId();
+    String getTitle();
+    String getSnippet();
+    String getAuthorName();
+    Instant getDate();
+    String getType();
+    Double getScore();
+}

--- a/src/main/java/dsd/api/cdmsa/repository/SearchRepository.java
+++ b/src/main/java/dsd/api/cdmsa/repository/SearchRepository.java
@@ -1,0 +1,76 @@
+package dsd.api.cdmsa.repository;
+
+import dsd.api.cdmsa.dto.SearchResultProjection;
+import dsd.api.cdmsa.model.RFC;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+@Repository
+public interface SearchRepository extends JpaRepository<RFC, Long> {
+
+    @Query(value = """
+        SELECT * FROM (
+            -- searching in ADRs
+            SELECT 
+                a.id, 
+                a.title, 
+                LEFT(a.context, 200) AS snippet, 
+                CONCAT(u.firstname, ' ', u.lastname) AS authorName, 
+                a.created_at AS date, 
+                'ADR' AS type, 
+                MATCH(a.title, a.context, a.decision) AGAINST(:query IN BOOLEAN MODE) AS score
+            FROM adrs a
+            JOIN rfc r ON a.rfc_id = r.id
+            JOIN app_users u ON r.user_id = u.id
+            WHERE 
+                MATCH(a.title, a.context, a.decision) AGAINST(:query IN BOOLEAN MODE)
+                
+                -- author filter (Optional)
+                AND (:authorId IS NULL OR r.user_id = :authorId)
+                
+                -- date filter (optional)
+                AND (:dateFrom IS NULL OR a.created_at >= :dateFrom)
+                AND (:dateTo IS NULL OR a.created_at <= :dateTo)
+
+            UNION ALL
+
+            -- searching in RFCs
+            SELECT 
+                r.id, 
+                r.title, 
+                LEFT(r.description, 200) AS snippet, 
+                CONCAT(u.firstname, ' ', u.lastname) AS authorName, 
+                r.created_at AS date, 
+                'RFC' AS type, 
+                MATCH(r.title, r.description) AGAINST(:query IN BOOLEAN MODE) AS score
+            FROM rfc r
+            JOIN app_users u ON r.user_id = u.id
+            WHERE 
+                MATCH(r.title, r.description) AGAINST(:query IN BOOLEAN MODE)
+                
+                -- same filters as ADRs
+                AND (:authorId IS NULL OR r.user_id = :authorId)
+                AND (:dateFrom IS NULL OR r.created_at >= :dateFrom)
+                AND (:dateTo IS NULL OR r.created_at <= :dateTo)
+        ) AS combined
+        
+        -- sorting
+        ORDER BY 
+            CASE WHEN :sort = 'date_desc' THEN date END DESC,
+            CASE WHEN :sort = 'date_asc'  THEN date END ASC,
+            CASE WHEN :sort = 'relevance' THEN score END DESC
+        LIMIT 50
+    """, nativeQuery = true)
+    List<SearchResultProjection> searchSimple(
+            @Param("query") String query,
+            @Param("sort") String sort,
+            @Param("authorId") Long authorId,
+            @Param("dateFrom") Instant dateFrom,
+            @Param("dateTo") Instant dateTo
+    );
+}

--- a/src/main/java/dsd/api/cdmsa/repository/SearchRepository.java
+++ b/src/main/java/dsd/api/cdmsa/repository/SearchRepository.java
@@ -15,7 +15,7 @@ public interface SearchRepository extends JpaRepository<RFC, Long> {
 
     @Query(value = """
         SELECT * FROM (
-            -- searching in ADRs
+            -- 1. SEARCHING IN ADRs
             SELECT 
                 a.id, 
                 a.title, 
@@ -25,21 +25,20 @@ public interface SearchRepository extends JpaRepository<RFC, Long> {
                 'ADR' AS type, 
                 MATCH(a.title, a.context, a.decision) AGAINST(:query IN BOOLEAN MODE) AS score
             FROM adrs a
-            JOIN rfc r ON a.rfc_id = r.id
+            JOIN rfc r ON a.rfc_id = r.id      -- Join con RFC per ottenere org_id e user
             JOIN app_users u ON r.user_id = u.id
             WHERE 
                 MATCH(a.title, a.context, a.decision) AGAINST(:query IN BOOLEAN MODE)
                 
-                -- author filter (Optional)
-                AND (:authorId IS NULL OR r.user_id = :authorId)
+                AND r.org_id = :orgId
                 
-                -- date filter (optional)
+                AND (:authorId IS NULL OR r.user_id = :authorId)
                 AND (:dateFrom IS NULL OR a.created_at >= :dateFrom)
                 AND (:dateTo IS NULL OR a.created_at <= :dateTo)
 
             UNION ALL
 
-            -- searching in RFCs
+            -- 2. SEARCHING IN RFCs
             SELECT 
                 r.id, 
                 r.title, 
@@ -53,13 +52,13 @@ public interface SearchRepository extends JpaRepository<RFC, Long> {
             WHERE 
                 MATCH(r.title, r.description) AGAINST(:query IN BOOLEAN MODE)
                 
-                -- same filters as ADRs
+                AND r.org_id = :orgId
+                
                 AND (:authorId IS NULL OR r.user_id = :authorId)
                 AND (:dateFrom IS NULL OR r.created_at >= :dateFrom)
                 AND (:dateTo IS NULL OR r.created_at <= :dateTo)
         ) AS combined
         
-        -- sorting
         ORDER BY 
             CASE WHEN :sort = 'date_desc' THEN date END DESC,
             CASE WHEN :sort = 'date_asc'  THEN date END ASC,
@@ -70,6 +69,7 @@ public interface SearchRepository extends JpaRepository<RFC, Long> {
             @Param("query") String query,
             @Param("sort") String sort,
             @Param("authorId") Long authorId,
+            @Param("orgId") Long orgId,
             @Param("dateFrom") Instant dateFrom,
             @Param("dateTo") Instant dateTo
     );

--- a/src/main/java/dsd/api/cdmsa/service/AdrService.java
+++ b/src/main/java/dsd/api/cdmsa/service/AdrService.java
@@ -7,6 +7,8 @@ import dsd.api.cdmsa.dto.AdrSpecificResponse;
 import dsd.api.cdmsa.dto.CreateAdrRequest;
 import dsd.api.cdmsa.dto.PublishAdrRequest;
 import dsd.api.cdmsa.dto.UpdateAdrRequest;
+import dsd.api.cdmsa.exception.RfcAlternativeNotAllowedException;
+import dsd.api.cdmsa.exception.RfcInvalidStatusException;
 import dsd.api.cdmsa.model.*;
 import dsd.api.cdmsa.repository.AdrRepository;
 import dsd.api.cdmsa.repository.RfcRepository;
@@ -324,6 +326,32 @@ public class AdrService {
         JsonNode rootNode = objectMapper.readTree(response.getBody());
         return rootNode.get("content").get("html_url").asText();
 
+    }
+
+    @Transactional
+    public void deleteAdr(Long adrId, Long orgId, Long userId) {
+        dsd.api.cdmsa.model.ADR adr = adrRepository.findByIdAndRfc_Org_Id(adrId, orgId)
+                .orElseThrow(() -> new EntityNotFoundException("ADR not found"));
+
+        if (!adr.getRfc().getUser().getId().equals(userId)) {
+            throw new RfcAlternativeNotAllowedException("Only the author can delete this ADR");
+        }
+
+        if (adr.getStatus() == dsd.api.cdmsa.model.ADR.Status.APPROVED || adr.getGitHubUrl() != null) {
+            throw new RfcInvalidStatusException("Cannot delete an ADR that has already been published/approved.");
+        }
+
+        RFC rfc = adr.getRfc();
+
+        // We "reset" the RFC status
+        rfc.setStatus(RFC.Status.UNDER_REVIEW);
+
+        rfc.setAdr(null);
+
+        rfcRepository.save(rfc);
+
+        // Deleting the adr
+        adrRepository.delete(adr);
     }
 
     /*

--- a/src/main/java/dsd/api/cdmsa/service/SearchService.java
+++ b/src/main/java/dsd/api/cdmsa/service/SearchService.java
@@ -1,0 +1,66 @@
+package dsd.api.cdmsa.service;
+
+import dsd.api.cdmsa.dto.SearchResult;
+import dsd.api.cdmsa.dto.SearchResultProjection;
+import dsd.api.cdmsa.repository.SearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+    private final SearchRepository searchRepository;
+
+    @Transactional(readOnly = true)
+    public List<SearchResult> search(String query, String sortParam, Long authorId, Instant dateFrom, Instant dateTo) {
+
+        // Avoid too short searches
+        if (query == null || query.trim().length() < 2) {
+            return List.of();
+        }
+
+        // Format for Boolean Mode
+        // Input: "login error" -> Output: "+login* +error*"
+        // This allows that is the user search for Migr instead of Migration, he still gets the results
+        StringBuilder sb = new StringBuilder();
+        String[] words = query.trim().split("\\s+");
+
+        for (String word : words) {
+            String clean = word.replaceAll("[^a-zA-Z0-9À-ÿ]", "");
+            if (!clean.isEmpty()) {
+                sb.append("+").append(clean).append("* ");
+            }
+        }
+
+        String formattedQuery = sb.toString().trim();
+        if (formattedQuery.isEmpty()) return List.of();
+
+        // Execute query, the default sort is by relevance
+        String sort = (sortParam == null || sortParam.isEmpty()) ? "relevance" : sortParam;
+
+        List<SearchResultProjection> rawResults = searchRepository.searchSimple(
+                formattedQuery,
+                sort,
+                authorId,
+                dateFrom,
+                dateTo
+        );
+
+        return rawResults.stream()
+                .map(r -> new SearchResult(
+                        r.getId(),
+                        r.getTitle(),
+                        r.getSnippet(),
+                        r.getAuthorName(),
+                        r.getDate(),
+                        r.getType(),
+                        r.getScore()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/dsd/api/cdmsa/service/SearchService.java
+++ b/src/main/java/dsd/api/cdmsa/service/SearchService.java
@@ -17,7 +17,7 @@ public class SearchService {
     private final SearchRepository searchRepository;
 
     @Transactional(readOnly = true)
-    public List<SearchResult> search(String query, String sortParam, Long authorId, Instant dateFrom, Instant dateTo) {
+    public List<SearchResult> search(String query, String sortParam, Long authorId, Long orgId, Instant dateFrom, Instant dateTo) {
 
         // Avoid too short searches
         if (query == null || query.trim().length() < 2) {
@@ -47,6 +47,7 @@ public class SearchService {
                 formattedQuery,
                 sort,
                 authorId,
+                orgId,
                 dateFrom,
                 dateTo
         );


### PR DESCRIPTION
This feature allow a user to search (through a searchbar) the most relevant adrs and rfcs w.r.t to the keywords he used in the search. When the results are retrieved then, the user is also able to filter (through data range or author) and also order by date. For the deletion of the adr, the idea is that when an adr is drafted but not yet approved, the user has the possibility of deleting it, this way its rfc becomes again in UNDER_REVIEW state.