### PR TITLE
Diagrams and attachments

### DIFF
--- a/src/main/java/dsd/api/cdmsa/controller/RfcController.java
+++ b/src/main/java/dsd/api/cdmsa/controller/RfcController.java
@@ -1,10 +1,16 @@
 package dsd.api.cdmsa.controller;
 
 import dsd.api.cdmsa.dto.*;
+import dsd.api.cdmsa.model.AlternativeAttachment;
+import dsd.api.cdmsa.model.RfcAttachment;
 import dsd.api.cdmsa.service.LLMService;
 import jakarta.validation.Valid;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -20,6 +26,7 @@ import dsd.api.cdmsa.exception.*;
 
 import dsd.api.cdmsa.model.UserPrincipal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 /**
  * REST controller responsible for handling RFC-related endpoints.
@@ -83,13 +90,16 @@ public class RfcController {
      * HTTP 201 Created on success.
      * Validation and business rules are handled inside RfcService.
      */
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<RfcResponse> createRfc(
-            @RequestBody CreateRfcRequest request,
-            HttpServletRequest httpRequest) {
+            // JSON part
+            @RequestPart("data") @Valid CreateRfcRequest request,
+            // Attachments part (optional)
+            @RequestPart(value = "files", required = false) List<MultipartFile> files,
+            HttpServletRequest httpRequest) throws IOException {
         Long userId = getCurrentUserId(httpRequest);
         Long orgId = getCurrentUserOrgId(httpRequest);
-        RfcResponse response = rfcService.createRfc(userId, orgId, request);
+        RfcResponse response = rfcService.createRfc(userId, orgId, request, files);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
@@ -134,13 +144,15 @@ public class RfcController {
      * Returns: AlternativeResponse
      * Status: 201 Created
      */
-    @PostMapping("/{rfcId}/alternatives")
-    public ResponseEntity<AlternativeResponse> createAlternative(
+    @PostMapping(value = "/{rfcId}/alternatives", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<AlternativeSpecificResponse> createAlternative(
             @PathVariable Long rfcId,
-            @RequestBody CreateAlternativeRequest request,
-            HttpServletRequest httpRequest) {
+            @RequestPart("data") @Valid CreateAlternativeRequest request,
+            @RequestPart(value = "files", required = false) List<MultipartFile> files,
+            HttpServletRequest httpRequest) throws IOException {
+
         Long userId = getCurrentUserId(httpRequest);
-        AlternativeResponse response = rfcService.addAlternative(rfcId, userId, request);
+        AlternativeSpecificResponse response = rfcService.addAlternative(rfcId, userId, request, files);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
@@ -199,4 +211,169 @@ public class RfcController {
         return ResponseEntity.ok(response);
     }
 
+    // UPDATE OR CREATE DIAGRAM
+    @PutMapping("/{rfcId}/diagram")
+    public ResponseEntity<RfcSpecificResponse> updateOrCreateRfcDiagram(
+            @PathVariable Long rfcId,
+            @RequestBody UpdateCreateDiagramRequest request,
+            HttpServletRequest httpRequest) {
+
+        Long userId = getCurrentUserId(httpRequest);
+        RfcSpecificResponse updatedRfc = rfcService.updateOrCreateDiagram(rfcId, userId, request.xmlContent());
+
+        return ResponseEntity.ok(updatedRfc);
+    }
+
+    // UPLOAD ATTACHMENTS
+    @PostMapping(value = "/{rfcId}/attachments", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<List<AttachmentResponse>> uploadAttachmentsToRfc(
+            @PathVariable Long rfcId,
+            @RequestParam("files") List<MultipartFile> files, // List of attachments
+            HttpServletRequest httpRequest) throws IOException {
+
+        Long userId = getCurrentUserId(httpRequest);
+
+        List<RfcAttachment> attachments = rfcService.uploadMultipleAttachments(rfcId, userId, files);
+
+        List<AttachmentResponse> response = attachments.stream()
+                .map(att -> new AttachmentResponse(
+                        att.getId(),
+                        att.getFileName(),
+                        att.getContentType(),
+                        att.getSize(),
+                        "/rfcs/attachments/download/RFC/" + att.getId()
+                ))
+                .toList();
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // probably not needed
+    @GetMapping("/{rfcId}/attachments")
+    public ResponseEntity<List<AttachmentResponse>> getAttachmentsForRfc(@PathVariable Long rfcId) {
+
+        List<RfcAttachment> entities = rfcService.getRfcAttachments(rfcId);
+
+        List<AttachmentResponse> dtos = entities.stream()
+                .map(att -> new AttachmentResponse(
+                        att.getId(),
+                        att.getFileName(),
+                        att.getContentType(),
+                        att.getSize(),
+                        "/rfcs/attachments/download/RFC/" + att.getId()))
+                .toList();
+
+        return ResponseEntity.ok(dtos);
+    }
+
+    // DOWNLOAD
+    @GetMapping("/attachments/{attachmentId}/download")
+    public ResponseEntity<Resource> downloadAttachment(@PathVariable Long attachmentId, HttpServletRequest httpRequest) {
+
+        Long userOrgId = getCurrentUserOrgId(httpRequest);
+
+        RfcService.FileDownloadDTO fileData = rfcService.downloadRfcAttachment(attachmentId, userOrgId);
+
+        return ResponseEntity.ok()
+                // Set type of file (image/png for example)
+                .contentType(MediaType.parseMediaType(fileData.contentType()))
+
+                // Header
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + fileData.fileName() + "\"")
+
+                .body(fileData.resource());
+    }
+
+    @PutMapping("/{rfcId}")
+    public ResponseEntity<RfcSpecificResponse> updateRfcFields(
+            @PathVariable Long rfcId,
+            @Valid @RequestBody UpdateRfcRequest request,
+            HttpServletRequest httpRequest) {
+
+        Long userId = getCurrentUserId(httpRequest);
+        Long orgId = getCurrentUserOrgId(httpRequest);
+
+        RfcSpecificResponse response = rfcService.updateRfcText(rfcId, userId, orgId, request);
+
+        return ResponseEntity.ok(response);
+    }
+
+
+    // Get specific alternative
+    @GetMapping("/alternatives/{altId}")
+    public ResponseEntity<AlternativeSpecificResponse> getAlternativeById(
+            @PathVariable Long altId,
+            HttpServletRequest httpRequest) {
+
+        Long userId = getCurrentUserId(httpRequest);
+        Long orgId = getCurrentUserOrgId(httpRequest);
+
+        AlternativeSpecificResponse response = rfcService.getAlternativeByIdForOrg(altId, orgId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    // Alternative diagram
+    @PutMapping("/alternatives/{altId}/diagram")
+    public ResponseEntity<AlternativeSpecificResponse> updateOrCreateAlternativeDiagram(
+            @PathVariable Long altId,
+            @RequestBody UpdateCreateDiagramRequest request,
+            HttpServletRequest httpRequest) {
+
+        Long userId = getCurrentUserId(httpRequest);
+        AlternativeSpecificResponse response = rfcService.updateOrCreateAlternativeDiagram(altId, userId, request.xmlContent());
+        return ResponseEntity.ok(response);
+    }
+
+    // Alternative attachments
+    @PostMapping(value = "/alternatives/{altId}/attachments", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<List<AttachmentResponse>> uploadAttachmentsToAlternative(
+            @PathVariable Long altId,
+            @RequestParam("files") List<MultipartFile> files,
+            HttpServletRequest httpRequest) throws IOException {
+
+        Long userId = getCurrentUserId(httpRequest);
+
+        List<AlternativeAttachment> attachments = rfcService.uploadMultipleAlternativeAttachments(altId, userId, files);
+
+        List<AttachmentResponse> response = attachments.stream()
+                .map(att -> new AttachmentResponse(
+                        att.getId(),
+                        att.getFileName(),
+                        att.getContentType(),
+                        att.getSize(),
+                        "/rfcs/alternatives/attachments/download/" + att.getId()
+                ))
+                .toList();
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // Download attachment
+    @GetMapping("/alternatives/attachments/{attachmentId}/download")
+    public ResponseEntity<Resource> downloadAlternativeAttachment(
+            @PathVariable Long attachmentId,
+            HttpServletRequest httpRequest) {
+
+        Long userOrgId = getCurrentUserOrgId(httpRequest);
+
+        RfcService.FileDownloadDTO fileData = rfcService.downloadAlternativeAttachment(attachmentId, userOrgId);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(fileData.contentType()))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + fileData.fileName() + "\"")
+                .body(fileData.resource());
+    }
+
+    @PutMapping("/alternatives/{altId}")
+    public ResponseEntity<AlternativeSpecificResponse> updateAlternativeFields(
+            @PathVariable Long altId,
+            @RequestBody UpdateAlternativeRequest request,
+            HttpServletRequest httpRequest) {
+
+        Long userId = getCurrentUserId(httpRequest);
+
+        AlternativeSpecificResponse response = rfcService.updateAlternative(altId, userId, request);
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/dsd/api/cdmsa/dto/AlternativeResponse.java
+++ b/src/main/java/dsd/api/cdmsa/dto/AlternativeResponse.java
@@ -10,6 +10,7 @@ public record AlternativeResponse(
         String cons,
         Long authorId,
         String authorName,
+        String addition,
         java.time.Instant createdAt,
         java.time.Instant updatedAt,
         int yes,
@@ -23,7 +24,8 @@ public record AlternativeResponse(
                 alternative.getPros(),
                 alternative.getCons(),
                 alternative.getAuthor() != null ? alternative.getAuthor().getId() : null,
-                alternative.getAuthor() != null ? alternative.getAuthor().getFirstname() : null,
+                alternative.getAuthor() != null ? alternative.getAuthor().getFirstname() + " " + alternative.getAuthor().getLastname() : null,
+                alternative.getAddition(),
                 alternative.getCreatedAt(),
                 alternative.getUpdatedAt(),
                 0,
@@ -38,7 +40,8 @@ public record AlternativeResponse(
                 alternative.getPros(),
                 alternative.getCons(),
                 alternative.getAuthor() != null ? alternative.getAuthor().getId() : null,
-                alternative.getAuthor() != null ? alternative.getAuthor().getFirstname() : null,
+                alternative.getAuthor() != null ? alternative.getAuthor().getFirstname() + " " + alternative.getAuthor().getLastname() : null,
+                alternative.getAddition(),
                 alternative.getCreatedAt(),
                 alternative.getUpdatedAt(), yes, no);
     }

--- a/src/main/java/dsd/api/cdmsa/dto/AlternativeSpecificResponse.java
+++ b/src/main/java/dsd/api/cdmsa/dto/AlternativeSpecificResponse.java
@@ -1,0 +1,21 @@
+package dsd.api.cdmsa.dto;
+
+import java.util.List;
+
+public record AlternativeSpecificResponse(
+        Long id,
+        String title,
+        String description,
+        String pros,
+        String cons,
+        String xml,
+        Long authorId,
+        String authorName,
+        String addition,
+        java.time.Instant createdAt,
+        java.time.Instant updatedAt,
+        int yes,
+        int no,
+        boolean isAuthor,
+        List<AttachmentResponse> attachments
+) {}

--- a/src/main/java/dsd/api/cdmsa/dto/AttachmentResponse.java
+++ b/src/main/java/dsd/api/cdmsa/dto/AttachmentResponse.java
@@ -1,0 +1,9 @@
+package dsd.api.cdmsa.dto;
+
+public record AttachmentResponse(
+        Long id,
+        String fileName,
+        String contentType,
+        Long size,
+        String downloadUrl
+) {}

--- a/src/main/java/dsd/api/cdmsa/dto/CreateAlternativeRequest.java
+++ b/src/main/java/dsd/api/cdmsa/dto/CreateAlternativeRequest.java
@@ -4,5 +4,6 @@ public record CreateAlternativeRequest(
                 String title,
                 String description,
                 String pros,
-                String cons) {
+                String cons,
+                String xml) {
 }

--- a/src/main/java/dsd/api/cdmsa/dto/CreateRfcRequest.java
+++ b/src/main/java/dsd/api/cdmsa/dto/CreateRfcRequest.java
@@ -3,6 +3,7 @@ package dsd.api.cdmsa.dto;
 public record CreateRfcRequest(
         String title,
         String description,
-        Long templateId
+        Long templateId,
+        String xml  // if null no diagram has been created (yet)
         ) {
 }

--- a/src/main/java/dsd/api/cdmsa/dto/RfcResponse.java
+++ b/src/main/java/dsd/api/cdmsa/dto/RfcResponse.java
@@ -13,9 +13,12 @@ public record RfcResponse(
         Long templateId,
         Long orgId,
         RFC.Status status,
+        String addition,
         java.time.Instant createdAt,
         java.time.Instant updatedAt,
+        String xml,
         Long commentCount,
         List<AlternativeResponse> alternatives,
-        List<CommentResponse> comments) {
+        List<CommentResponse> comments,
+        List<AttachmentResponse> attachments) {
 }

--- a/src/main/java/dsd/api/cdmsa/dto/RfcSpecificResponse.java
+++ b/src/main/java/dsd/api/cdmsa/dto/RfcSpecificResponse.java
@@ -13,10 +13,13 @@ public record RfcSpecificResponse(
         Long templateId,
         Long orgId,
         RFC.Status status,
+        String addition,
         java.time.Instant createdAt,
         java.time.Instant updatedAt,
+        String xml,
         boolean isAuthor,
         List<AlternativeResponse> alternatives,
-        List<CommentResponse> comments) {
+        List<CommentResponse> comments,
+        List<AttachmentResponse> attachments) {
 
 }

--- a/src/main/java/dsd/api/cdmsa/dto/UpdateAlternativeRequest.java
+++ b/src/main/java/dsd/api/cdmsa/dto/UpdateAlternativeRequest.java
@@ -1,0 +1,18 @@
+package dsd.api.cdmsa.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record UpdateAlternativeRequest(
+        @Size(max = 150, message = "Title too long")
+        String title,
+
+        @Size(max = 4000, message = "Description too long")
+        String description,
+
+        @Size(max = 2000, message = "Pros text too long")
+        String pros,
+
+        @Size(max = 2000, message = "Cons text too long")
+        String cons,
+        String addition
+) {}

--- a/src/main/java/dsd/api/cdmsa/dto/UpdateCreateDiagramRequest.java
+++ b/src/main/java/dsd/api/cdmsa/dto/UpdateCreateDiagramRequest.java
@@ -1,0 +1,6 @@
+package dsd.api.cdmsa.dto;
+
+public record UpdateCreateDiagramRequest(
+        String xmlContent
+) {
+}

--- a/src/main/java/dsd/api/cdmsa/dto/UpdateRfcRequest.java
+++ b/src/main/java/dsd/api/cdmsa/dto/UpdateRfcRequest.java
@@ -1,0 +1,12 @@
+package dsd.api.cdmsa.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateRfcRequest(
+        @NotBlank(message = "Title cannot be empty")
+        String title,
+
+        @NotBlank(message = "Description cannot be empty")
+        String description,
+        String addition
+) {}

--- a/src/main/java/dsd/api/cdmsa/model/Alternative.java
+++ b/src/main/java/dsd/api/cdmsa/model/Alternative.java
@@ -39,6 +39,13 @@ public class Alternative {
     @Column(length = 2000)
     private String cons;
 
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String xml;
+
+    @Column(columnDefinition = "TEXT")
+    private String addition;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private java.time.Instant createdAt;
 

--- a/src/main/java/dsd/api/cdmsa/model/AlternativeAttachment.java
+++ b/src/main/java/dsd/api/cdmsa/model/AlternativeAttachment.java
@@ -1,0 +1,32 @@
+package dsd.api.cdmsa.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "alternative_attachments")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AlternativeAttachment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "alternative_id", nullable = false)
+    private Alternative alternative;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(nullable = false)
+    private String filePath;
+
+    @Column(nullable = false)
+    private String contentType;
+
+    private Long size;
+}

--- a/src/main/java/dsd/api/cdmsa/model/RFC.java
+++ b/src/main/java/dsd/api/cdmsa/model/RFC.java
@@ -1,20 +1,6 @@
 package dsd.api.cdmsa.model;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -67,6 +53,13 @@ public class RFC {
 
     @OneToMany(mappedBy = "rfc", cascade = CascadeType.ALL, orphanRemoval = true)
     private java.util.Set<Alternative> alternatives = new java.util.HashSet<>();
+
+    @Lob
+    @Column(name = "diagram_xml", columnDefinition = "TEXT")
+    private String xml;
+
+    @Column(columnDefinition = "TEXT")
+    private String addition;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private java.time.Instant createdAt;

--- a/src/main/java/dsd/api/cdmsa/model/RfcAttachment.java
+++ b/src/main/java/dsd/api/cdmsa/model/RfcAttachment.java
@@ -1,0 +1,35 @@
+package dsd.api.cdmsa.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "rfc_attachment")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RfcAttachment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "rfc_id", nullable = false)
+    private RFC rfc;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(nullable = false)
+    private String filePath;
+
+    @Column(nullable = false)
+    private String contentType; // for example application/pdf
+
+    @Column(nullable = false)
+    private Long size; // in bytes
+
+}

--- a/src/main/java/dsd/api/cdmsa/repository/AlternativeAttachmentRepository.java
+++ b/src/main/java/dsd/api/cdmsa/repository/AlternativeAttachmentRepository.java
@@ -1,0 +1,11 @@
+package dsd.api.cdmsa.repository;
+
+import dsd.api.cdmsa.model.AlternativeAttachment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface AlternativeAttachmentRepository extends JpaRepository<AlternativeAttachment, Long> {
+    List<AlternativeAttachment> findByAlternativeId(Long alternativeId);
+}

--- a/src/main/java/dsd/api/cdmsa/repository/RfcAttachmentRepository.java
+++ b/src/main/java/dsd/api/cdmsa/repository/RfcAttachmentRepository.java
@@ -1,0 +1,10 @@
+package dsd.api.cdmsa.repository;
+
+import dsd.api.cdmsa.model.RfcAttachment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RfcAttachmentRepository extends JpaRepository<RfcAttachment, Long> {
+    List<RfcAttachment> findByRfcId(Long rfcId);
+}

--- a/src/main/java/dsd/api/cdmsa/service/RfcService.java
+++ b/src/main/java/dsd/api/cdmsa/service/RfcService.java
@@ -5,6 +5,7 @@ import dsd.api.cdmsa.model.*;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -21,6 +22,15 @@ import dsd.api.cdmsa.exception.RfcDependencyNotFoundException;
 import dsd.api.cdmsa.exception.RfcInvalidStatusException;
 import dsd.api.cdmsa.exception.RfcNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.File;
+import java.io.IOException;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +44,11 @@ public class RfcService {
     private final AlternativeRepository alternativeRepository;
     private final CommentRepository commentRepository;
     private final VoteRepository voteRepository;
+    private final RfcAttachmentRepository rfcAttachmentRepository;
+    private final AlternativeAttachmentRepository alternativeAttachmentRepository;
+
+    // Folder where to upload attachments (all inside here right now)
+    private final String UPLOAD_DIR = "C:\\Users\\carlo\\OneDrive\\Desktop\\uploads\\";
 
     @Transactional
     public RfcResponse postCommentToRfc(Long rfcId, Long userId, CreateCommentRequest request) {
@@ -77,7 +92,7 @@ public class RfcService {
     // ---------- US-12: Create RFC ----------
 
     @Transactional
-    public RfcResponse createRfc(Long userId, Long orgId, CreateRfcRequest request) {
+    public RfcResponse createRfc(Long userId, Long orgId, CreateRfcRequest request, List<MultipartFile> files) throws IOException {
 
         // Validate request body
         if (request == null) {
@@ -110,11 +125,89 @@ public class RfcService {
         rfc.setTemplate(template);
         rfc.setOrg(org);
         rfc.setUser(user);
+        if (request.xml() != null) {
+            rfc.setXml(request.xml().trim());
+        }
         // Status defaults to UNDER_REVIEW in RFC model
 
         // Persist and map
         RFC saved = rfcRepository.save(rfc);
-        return toResponse(saved);
+
+        // Check attachments presence
+        if (files != null && !files.isEmpty()) {
+            for (MultipartFile file : files) {
+                // Saving the uploaded files
+                saveAttachmentInternal(saved, file);
+            }
+        }
+
+        // Getting the just upload files
+        List<RfcAttachment> freshAttachments = rfcAttachmentRepository.findByRfcId(saved.getId());
+
+        if (freshAttachments == null || freshAttachments.isEmpty()) {
+            // Case A: no attachments
+            return toResponse(saved);
+        } else {
+            // Case B: attachments
+            return toResponse(saved, freshAttachments);
+        }
+    }
+
+
+    private RfcResponse toResponse(RFC rfc, List<RfcAttachment> attachments) {
+        int count = commentRepository.findByRfcId(rfc.getId()).size();
+
+        List<AttachmentResponse> attachmentDtos = attachments.stream()
+                .map(this::toAttachmentDto)
+                .toList();
+
+        return new RfcResponse(
+                rfc.getId(),
+                rfc.getTitle(),
+                rfc.getDescription(),
+                rfc.getUser() != null ? rfc.getUser().getId() : null,
+                rfc.getUser() != null ? rfc.getUser().getFirstname() : null,
+                rfc.getTemplate() != null ? rfc.getTemplate().getId() : null,
+                rfc.getOrg() != null ? rfc.getOrg().getId() : null,
+                rfc.getStatus(),
+                rfc.getAddition(),
+                rfc.getCreatedAt(),
+                rfc.getUpdatedAt(),
+                rfc.getXml(),
+                (long) count,
+                List.of(), // alternatives summary
+                List.of(), // comments summary
+                attachmentDtos // returning also the list of attachments
+        );
+    }
+
+    private RfcAttachment saveAttachmentInternal(RFC rfc, MultipartFile file) throws IOException {
+
+        // Clean filename
+        String originalFileName = StringUtils.cleanPath(file.getOriginalFilename());
+        if (originalFileName.contains("..")) {
+            throw new IOException("Filename contains invalid path sequence " + originalFileName);
+        }
+
+        // Create folder where to save (if not present already)
+        String uniqueFileName = System.currentTimeMillis() + "_" + originalFileName;
+        String fullPath = UPLOAD_DIR + uniqueFileName;
+
+        File directory = new File(UPLOAD_DIR);
+        if (!directory.exists()) directory.mkdirs();
+
+        // Writing
+        file.transferTo(new File(fullPath));
+
+        // Saving in the database the metadata of the attachment
+        RfcAttachment att = new RfcAttachment();
+        att.setRfc(rfc);
+        att.setFileName(originalFileName);
+        att.setFilePath(fullPath);
+        att.setContentType(file.getContentType());
+        att.setSize(file.getSize());
+
+        return rfcAttachmentRepository.save(att);
     }
 
     @Transactional(readOnly = true)
@@ -147,9 +240,11 @@ public class RfcService {
      */
     @Transactional(readOnly = true)
     public RfcSpecificResponse getRfcByIdForOrg(Long rfcId, Long orgId, Long userId) {
+
         RFC rfc = rfcRepository.findByIdAndOrgId(rfcId, orgId)
                 .orElseThrow(() -> new RfcNotFoundException("RFC not found with id " + rfcId));
         RfcResponse detailedRfc = toDetailedResponse(rfc);
+
         // Determine if the requesting user is the author of the RFC
         boolean isAuthor = rfc.getUser().getId().equals(userId);
         return new RfcSpecificResponse(
@@ -161,11 +256,14 @@ public class RfcService {
             rfc.getTemplate() != null ? rfc.getTemplate().getId() : null,
             rfc.getOrg() != null ? rfc.getOrg().getId() : null,
             rfc.getStatus(),
+            rfc.getAddition(),
             rfc.getCreatedAt(),
             rfc.getUpdatedAt(),
+            rfc.getXml(),
             isAuthor,
             detailedRfc.alternatives(),
-            detailedRfc.comments());
+            detailedRfc.comments(),
+            detailedRfc.attachments());
     }
 
     private RfcResponse toResponse(RFC rfc) {
@@ -180,10 +278,13 @@ public class RfcService {
                 rfc.getTemplate() != null ? rfc.getTemplate().getId() : null,
                 rfc.getOrg() != null ? rfc.getOrg().getId() : null,
                 rfc.getStatus(),
+                rfc.getAddition(),
                 rfc.getCreatedAt(),
                 rfc.getUpdatedAt(),
+                rfc.getXml(),
                 (long) count,
                 java.util.List.of(), // lightweight list for summary
+                java.util.List.of(),
                 java.util.List.of());
     }
 
@@ -214,6 +315,11 @@ public class RfcService {
                 .map(root -> buildThreaded(root, childrenMap))
                 .toList();
 
+        List<RfcAttachment> attachments = rfcAttachmentRepository.findByRfcId(rfc.getId());
+        List<AttachmentResponse> attachmentDtos = attachments.stream()
+                .map(this::toAttachmentDto)
+                .toList();
+
         return new RfcResponse(
                 rfc.getId(),
                 rfc.getTitle(),
@@ -223,11 +329,24 @@ public class RfcService {
                 rfc.getTemplate() != null ? rfc.getTemplate().getId() : null,
                 rfc.getOrg() != null ? rfc.getOrg().getId() : null,
                 rfc.getStatus(),
+                rfc.getAddition(),
                 rfc.getCreatedAt(),
-            rfc.getUpdatedAt(),
-            (long) comments.size(),
-            alts,
-            threaded);
+                rfc.getUpdatedAt(),
+                rfc.getXml(),
+                (long) comments.size(),
+                alts,
+                threaded,
+                attachmentDtos);
+    }
+
+    private AttachmentResponse toAttachmentDto(RfcAttachment att) {
+        return new AttachmentResponse(
+                att.getId(),
+                att.getFileName(),
+                att.getContentType(),
+                att.getSize(),
+                "/rfcs/attachments/download/RFC/" + att.getId()
+        );
     }
 
     private CommentResponse buildThreaded(Comment comment, Map<Long, List<Comment>> childrenMap) {
@@ -242,54 +361,6 @@ public class RfcService {
 
     // ---------- Alternatives (POST & GET) ----------
 
-    @Transactional
-    public AlternativeResponse addAlternative(Long rfcId, Long userId, CreateAlternativeRequest request) {
-
-        // Validate basic payload
-        if (request == null) {
-            throw new RfcAlternativeBadRequestException("Request body cannot be null");
-        }
-        if (request.title() == null || request.title().isBlank()) {
-            throw new RfcAlternativeBadRequestException("Title is required");
-        }
-        if (request.description() == null || request.description().isBlank()) {
-            throw new RfcAlternativeBadRequestException("Description is required");
-        }
-
-        // Load RFC
-        RFC rfc = rfcRepository.findById(rfcId)
-                .orElseThrow(() -> new RfcNotFoundException("RFC not found with id " + rfcId));
-
-        // Check status: only UNDER_REVIEW allows new alternatives
-        if (rfc.getStatus() != RFC.Status.UNDER_REVIEW) {
-            throw new RfcInvalidStatusException(
-                    "Alternatives can only be created for RFCs in UNDER_REVIEW status");
-        }
-
-        // Check authorization: only RFC author can create alternatives
-        if (!rfc.getUser().getId().equals(userId)) {
-            throw new RfcAlternativeNotAllowedException(
-                    "Only the author of the RFC is allowed to create alternatives");
-        }
-
-        // Build and persist alternative
-        Alternative alternative = new Alternative();
-        alternative.setRfc(rfc);
-        alternative.setTitle(request.title().trim());
-        alternative.setDescription(request.description().trim());
-        alternative.setAuthor(rfc.getUser());
-
-        // If pros/cons exist in the request and entity:
-        alternative.setPros(request.pros());
-        alternative.setCons(request.cons());
-
-        Alternative saved = alternativeRepository.save(alternative);
-        // Update RFC updated timestamp to reflect new alternative
-        rfc.setUpdatedAt(java.time.Instant.now());
-        rfcRepository.save(rfc);
-
-        return AlternativeResponse.fromEntity(saved);
-    }
 
     @Transactional(readOnly = true)
     public List<AlternativeResponse> listAlternatives(Long rfcId) {
@@ -334,7 +405,7 @@ public class RfcService {
             throw new RfcInvalidStatusException("RFC is not under review");
         }
 
-        if (rfc.getUser().getId() != userId) {
+        if (!Objects.equals(rfc.getUser().getId(), userId)) {
             throw new RfcAlternativeNotAllowedException("Only the author can close this RFC");
         }
 
@@ -407,6 +478,333 @@ public class RfcService {
         int yesCount = voteRepository.countByAlternativeAndOutcome(alternative, true);
         int noCount = voteRepository.countByAlternativeAndOutcome(alternative, false);
         return new VoteResponse(yesCount, noCount);
+    }
+
+    @Transactional
+    public RfcSpecificResponse updateOrCreateDiagram(Long rfcId, Long userId, String xmlContent) {
+
+        RFC rfc = rfcRepository.findById(rfcId)
+                .orElseThrow(() -> new RfcNotFoundException("RFC not found"));
+
+        // Check author
+        if (!rfc.getUser().getId().equals(userId)) {
+            throw new RfcAlternativeNotAllowedException("Only the author can edit the diagram");
+        }
+
+        // Check status
+        if (rfc.getStatus() != RFC.Status.UNDER_REVIEW) {
+            throw new RfcInvalidStatusException("Cannot edit diagram of a closed RFC");
+        }
+
+        rfc.setXml(xmlContent != null ? xmlContent.trim() : null);
+
+        rfcRepository.save(rfc);
+        return getRfcByIdForOrg(rfcId, rfc.getOrg().getId(), userId);
+    }
+
+
+
+    @Transactional
+    public List<RfcAttachment> uploadMultipleAttachments(Long rfcId, Long userId, List<MultipartFile> files) throws IOException {
+
+        RFC rfc = rfcRepository.findById(rfcId)
+                .orElseThrow(() -> new RfcNotFoundException("RFC not found with id " + rfcId));
+
+        if (files == null || files.isEmpty()) {
+            throw new IllegalArgumentException("No files provided");
+        }
+
+        File directory = new File(UPLOAD_DIR);
+        if (!directory.exists()) {
+            directory.mkdirs();
+        }
+
+        List<RfcAttachment> savedAttachments = new java.util.ArrayList<>();
+
+        for (MultipartFile file : files) {
+            RfcAttachment saved = saveAttachmentInternal(rfc, file);
+            savedAttachments.add(saved);
+        }
+
+        return savedAttachments;
+    }
+
+    // probably not needed
+    @Transactional(readOnly = true)
+    public List<RfcAttachment> getRfcAttachments(Long rfcId) {
+
+        if (!rfcRepository.existsById(rfcId)) {
+            throw new RfcNotFoundException("RFC not found with id " + rfcId);
+        }
+
+        return rfcAttachmentRepository.findByRfcId(rfcId);
+    }
+
+    // DTO interno per passare i dati al Controller in modo pulito
+    public record FileDownloadDTO(Resource resource, String fileName, String contentType) {}
+
+    @Transactional(readOnly = true)
+    public FileDownloadDTO downloadRfcAttachment(Long attachmentId, Long userOrgId) {
+
+        // Get metadata from the database
+        RfcAttachment attachment = rfcAttachmentRepository.findById(attachmentId)
+                .orElseThrow(() -> new EntityNotFoundException("Attachment not found with id " + attachmentId));
+
+        Long resourceOrgId = attachment.getRfc().getOrg().getId();
+
+        if (!resourceOrgId.equals(userOrgId)) {
+            throw new RfcAlternativeNotAllowedException("You are not authorized to download this file.");
+        }
+
+
+        try {
+            // Retrieve file from disk
+            Path filePath = Paths.get(attachment.getFilePath());
+            Resource resource = new UrlResource(filePath.toUri());
+
+            // Checks
+            if (resource.exists() && resource.isReadable()) {
+                return new FileDownloadDTO(
+                        resource,
+                        attachment.getFileName(),
+                        attachment.getContentType()
+                );
+            } else {
+                throw new RuntimeException("File not found or not readable on disk: " + attachment.getFileName());
+            }
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Error: " + e.getMessage());
+        }
+    }
+
+    @Transactional
+    public RfcSpecificResponse updateRfcText(Long rfcId, Long userId, Long orgId, UpdateRfcRequest request) {
+
+        RFC rfc = rfcRepository.findByIdAndOrgId(rfcId, orgId)
+                .orElseThrow(() -> new RfcNotFoundException("RFC not found with id " + rfcId));
+
+        if (!rfc.getUser().getId().equals(userId)) {
+            throw new RfcAlternativeNotAllowedException("Only the author can edit the RFC details");
+        }
+
+        if (rfc.getStatus() != RFC.Status.UNDER_REVIEW) {
+            throw new RfcInvalidStatusException("Cannot edit an RFC that is closed");
+        }
+
+        rfc.setTitle(request.title().trim());
+        rfc.setDescription(request.description().trim());
+        if (request.addition() != null) {
+            rfc.setAddition(request.addition().trim());
+        }
+
+        rfcRepository.save(rfc);
+
+        return getRfcByIdForOrg(rfcId, orgId, userId);
+    }
+
+
+    @Transactional
+    public AlternativeSpecificResponse addAlternative(Long rfcId, Long userId, CreateAlternativeRequest request, List<MultipartFile> files) throws IOException {
+
+        if (request == null) throw new RfcAlternativeBadRequestException("Request body cannot be null");
+        if (request.title() == null || request.title().isBlank()) throw new RfcAlternativeBadRequestException("Request title cannot be null");
+        if (request.description() == null || request.description().isBlank()) throw new RfcAlternativeBadRequestException("Request description cannot be null");
+
+        RFC rfc = rfcRepository.findById(rfcId)
+                .orElseThrow(() -> new RfcNotFoundException("RFC not found with id " + rfcId));
+
+        if (rfc.getStatus() != RFC.Status.UNDER_REVIEW) {
+            throw new RfcInvalidStatusException("Alternatives can only be created for RFCs in UNDER_REVIEW status");
+        }
+        if (!rfc.getUser().getId().equals(userId)) {
+            throw new RfcAlternativeNotAllowedException("Only the author of the RFC is allowed to create alternatives");
+        }
+
+        Alternative alternative = new Alternative();
+        alternative.setRfc(rfc);
+        alternative.setTitle(request.title().trim());
+        alternative.setDescription(request.description().trim());
+        alternative.setAuthor(rfc.getUser());
+        alternative.setPros(request.pros());
+        alternative.setCons(request.cons());
+        if (request.xml() != null) {
+            alternative.setXml(request.xml().trim());
+        }
+        // addition will be set null by default
+
+        Alternative saved = alternativeRepository.save(alternative);
+        rfc.setUpdatedAt(java.time.Instant.now());
+        rfcRepository.save(rfc);
+
+        // Handle Files
+        if (files != null && !files.isEmpty()) {
+            for (MultipartFile file : files) {
+                saveAlternativeAttachmentInternal(saved, file);
+            }
+        }
+
+        return getAlternativeByIdForOrg(saved.getId(), rfc.getOrg().getId(), userId);
+    }
+
+    @Transactional(readOnly = true)
+    public AlternativeSpecificResponse getAlternativeByIdForOrg(Long altId, Long orgId, Long userId) {
+        Alternative alt = alternativeRepository.findById(altId)
+                .orElseThrow(() -> new EntityNotFoundException("Alternative not found"));
+
+        if (!alt.getRfc().getOrg().getId().equals(orgId)) {
+            throw new RfcNotFoundException("Alternative not found in this organization");
+        }
+
+        int yesCount = voteRepository.countByAlternativeAndOutcome(alt, true);
+        int noCount = voteRepository.countByAlternativeAndOutcome(alt, false);
+        boolean isAuthor = alt.getAuthor().getId().equals(userId);
+
+        List<AlternativeAttachment> attachments = alternativeAttachmentRepository.findByAlternativeId(altId);
+        List<AttachmentResponse> attachmentDtos = attachments.stream()
+                .map(this::toAlternativeAttachmentDto)
+                .toList();
+
+        return new AlternativeSpecificResponse(
+                alt.getId(),
+                alt.getTitle(),
+                alt.getDescription(),
+                alt.getPros(),
+                alt.getCons(),
+                alt.getXml(),
+                alt.getAuthor().getId(),
+                alt.getAuthor().getFirstname(),
+                alt.getAddition(),
+                alt.getCreatedAt(),
+                alt.getUpdatedAt(),
+                yesCount,
+                noCount,
+                isAuthor,
+                attachmentDtos
+        );
+    }
+
+    @Transactional
+    public AlternativeSpecificResponse updateOrCreateAlternativeDiagram(Long altId, Long userId, String xmlContent) {
+        Alternative alt = alternativeRepository.findById(altId)
+                .orElseThrow(() -> new EntityNotFoundException("Alternative not found"));
+
+        if (!alt.getAuthor().getId().equals(userId)) {
+            throw new RfcAlternativeNotAllowedException("Only the author can edit the diagram");
+        }
+        if (alt.getRfc().getStatus() != RFC.Status.UNDER_REVIEW) {
+            throw new RfcInvalidStatusException("Cannot edit diagram of a closed RFC");
+        }
+
+        alt.setXml(xmlContent != null ? xmlContent.trim() : null);
+        alternativeRepository.save(alt);
+
+        return getAlternativeByIdForOrg(altId, alt.getRfc().getOrg().getId(), userId);
+    }
+
+    @Transactional
+    public List<AlternativeAttachment> uploadMultipleAlternativeAttachments(Long altId, Long userId, List<MultipartFile> files) throws IOException {
+        Alternative alt = alternativeRepository.findById(altId)
+                .orElseThrow(() -> new EntityNotFoundException("Alternative not found"));
+
+        if (!alt.getAuthor().getId().equals(userId)) {
+            throw new RfcAlternativeNotAllowedException("Only the author can upload files");
+        }
+
+        // Create folder if needed
+        File directory = new File(UPLOAD_DIR);
+        if (!directory.exists()) directory.mkdirs();
+
+        List<AlternativeAttachment> savedAttachments = new java.util.ArrayList<>();
+        for (MultipartFile file : files) {
+            savedAttachments.add(saveAlternativeAttachmentInternal(alt, file));
+        }
+        return savedAttachments;
+    }
+
+    @Transactional(readOnly = true)
+    public FileDownloadDTO downloadAlternativeAttachment(Long attachmentId, Long userOrgId) {
+        AlternativeAttachment attachment = alternativeAttachmentRepository.findById(attachmentId)
+                .orElseThrow(() -> new EntityNotFoundException("Attachment not found"));
+
+        Long resourceOrgId = attachment.getAlternative().getRfc().getOrg().getId();
+        if (!resourceOrgId.equals(userOrgId)) {
+            throw new RfcAlternativeNotAllowedException("You are not authorized to download this file.");
+        }
+
+        try {
+            Path filePath = Paths.get(attachment.getFilePath());
+            Resource resource = new UrlResource(filePath.toUri());
+            if (resource.exists() && resource.isReadable()) {
+                return new FileDownloadDTO(resource, attachment.getFileName(), attachment.getContentType());
+            } else {
+                throw new RuntimeException("File not found on disk");
+            }
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Error: " + e.getMessage());
+        }
+    }
+
+    private AlternativeAttachment saveAlternativeAttachmentInternal(Alternative alt, MultipartFile file) throws IOException {
+        String originalFileName = StringUtils.cleanPath(file.getOriginalFilename());
+        if (originalFileName.contains("..")) throw new IOException("Invalid filename");
+
+        String uniqueFileName = System.currentTimeMillis() + "_ALT_" + originalFileName;
+        String fullPath = UPLOAD_DIR + uniqueFileName;
+
+        File directory = new File(UPLOAD_DIR);
+        if (!directory.exists()) directory.mkdirs();
+
+        file.transferTo(new File(fullPath));
+
+        AlternativeAttachment att = new AlternativeAttachment();
+        att.setAlternative(alt);
+        att.setFileName(originalFileName);
+        att.setFilePath(fullPath);
+        att.setContentType(file.getContentType());
+        att.setSize(file.getSize());
+
+        return alternativeAttachmentRepository.save(att);
+    }
+
+    private AttachmentResponse toAlternativeAttachmentDto(AlternativeAttachment att) {
+        return new AttachmentResponse(
+                att.getId(),
+                att.getFileName(),
+                att.getContentType(),
+                att.getSize(),
+                "/rfcs/alternatives/attachments/download/" + att.getId() // distinct URL
+        );
+    }
+
+    @Transactional
+    public AlternativeSpecificResponse updateAlternative(Long altId, Long userId, UpdateAlternativeRequest request) {
+        Alternative alt = alternativeRepository.findById(altId)
+                .orElseThrow(() -> new EntityNotFoundException("Alternative not found"));
+
+        RFC rfc = alt.getRfc();
+
+        if (rfc.getStatus() != RFC.Status.UNDER_REVIEW) {
+            throw new RfcInvalidStatusException("Cannot modify alternative when RFC is closed");
+        }
+
+        if (!alt.getAuthor().getId().equals(userId)) {
+            throw new RfcAlternativeNotAllowedException("Only the author of the alternative can modify it");
+        }
+
+        if (request.title() != null) alt.setTitle(request.title().trim());
+        if (request.description() != null) alt.setDescription(request.description().trim());
+        if (request.pros() != null) alt.setPros(request.pros());
+        if (request.cons() != null) alt.setCons(request.cons());
+        if (request.addition() != null) {
+            alt.setAddition(request.addition().trim());
+        }
+
+        alternativeRepository.save(alt);
+
+        rfc.setUpdatedAt(java.time.Instant.now());
+        rfcRepository.save(rfc);
+
+        return getAlternativeByIdForOrg(altId, rfc.getOrg().getId(), userId);
     }
 
 }

--- a/src/test/java/dsd/api/cdmsa/unit/RfcServiceTest.java
+++ b/src/test/java/dsd/api/cdmsa/unit/RfcServiceTest.java
@@ -6,10 +6,10 @@ import dsd.api.cdmsa.model.*;
 import dsd.api.cdmsa.repository.*;
 import dsd.api.cdmsa.service.RfcService;
 
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -19,7 +19,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.mock.web.MockMultipartFile;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -38,10 +42,13 @@ class RfcServiceTest {
     private RfcRepository rfcRepository;
 
     @Mock
-    private AdrRepository adrRepository;
+    private AlternativeAttachmentRepository alternativeAttachmentRepository;
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private RfcAttachmentRepository rfcAttachmentRepository;
 
     @Mock
     private TemplateRepository templateRepository;
@@ -65,25 +72,23 @@ class RfcServiceTest {
     // createRfc
     // ------------------------------------------------------------
 
+
     @Test
-    void createRfc_shouldCreateRfc_whenValidRequestAndDependenciesExist() {
+    void createRfc_shouldCreateRfc_whenValidRequestAndDependenciesExist() throws IOException {
         Long userId = 1L;
         Long orgId = 10L;
         Long templateId = 5L;
 
+        // DTO Update: (title, description, templateId, xml) - NO addition
         CreateRfcRequest request = new CreateRfcRequest(
                 "  My RFC  ",
                 "Desc",
-                templateId);
+                templateId,
+                null);
 
-        User author = new User();
-        author.setId(userId);
-
-        Organization org = new Organization();
-        org.setId(orgId);
-
-        Template template = new Template();
-        template.setId(templateId);
+        User author = new User(); author.setId(userId);
+        Organization org = new Organization(); org.setId(orgId);
+        Template template = new Template(); template.setId(templateId);
 
         RFC rfc = new RFC();
         rfc.setId(100L);
@@ -92,17 +97,24 @@ class RfcServiceTest {
         rfc.setUser(author);
         rfc.setTemplate(template);
         rfc.setOrg(org);
+        rfc.setStatus(RFC.Status.UNDER_REVIEW);
 
+        // Mocks
         when(userRepository.findById(userId)).thenReturn(Optional.of(author));
         when(templateRepository.findById(templateId)).thenReturn(Optional.of(template));
         when(organizationRepository.findById(orgId)).thenReturn(Optional.of(org));
         when(rfcRepository.save(any(RFC.class))).thenReturn(rfc);
-        when(commentRepository.findByRfcId(rfc.getId())).thenReturn(Collections.emptyList());
 
-        RfcResponse response = rfcService.createRfc(userId, orgId, request);
+        // Mocks per la costruzione della risposta (allegati e commenti)
+        when(commentRepository.findByRfcId(rfc.getId())).thenReturn(Collections.emptyList());
+        when(rfcAttachmentRepository.findByRfcId(rfc.getId())).thenReturn(Collections.emptyList());
+
+        // Esecuzione (passiamo null ai files per simulare assenza allegati)
+        RfcResponse response = rfcService.createRfc(userId, orgId, request, null);
 
         assertNotNull(response);
-        // capturamos el RFC que se guardó para asegurar que el título está trimmed
+
+        // Verifica trimming titolo
         ArgumentCaptor<RFC> captor = ArgumentCaptor.forClass(RFC.class);
         verify(rfcRepository).save(captor.capture());
         assertEquals("My RFC", captor.getValue().getTitle());
@@ -111,7 +123,7 @@ class RfcServiceTest {
     @Test
     void createRfc_shouldThrowBadRequest_whenRequestIsNull() {
         assertThrows(RfcBadRequestException.class,
-                () -> rfcService.createRfc(1L, 10L, null));
+                () -> rfcService.createRfc(1L, 10L, null, null));
     }
 
     @Test
@@ -119,11 +131,13 @@ class RfcServiceTest {
         CreateRfcRequest request = new CreateRfcRequest(
                 "  ",
                 "Desc",
-                1L);
+                1L,
+                null);
 
         assertThrows(RfcBadRequestException.class,
-                () -> rfcService.createRfc(1L, 10L, request));
+                () -> rfcService.createRfc(1L, 10L, request, null));
     }
+
 
     // ------------------------------------------------------------
     // getRfcById / listRfcs / listRfcsByOrg
@@ -240,7 +254,7 @@ class RfcServiceTest {
     @Test
     void addAlternative_shouldThrowBadRequest_whenRequestNull() {
         assertThrows(RfcAlternativeBadRequestException.class,
-                () -> rfcService.addAlternative(1L, 1L, null));
+                () -> rfcService.addAlternative(1L, 1L, null, null));
     }
 
     @Test
@@ -254,10 +268,10 @@ class RfcServiceTest {
 
         when(rfcRepository.findById(rfcId)).thenReturn(Optional.of(rfc));
 
-        CreateAlternativeRequest request = new CreateAlternativeRequest("Alt", "Desc", "Pros", "Cons");
+        CreateAlternativeRequest request = new CreateAlternativeRequest("Alt", "Desc", "Pros", "Cons", null);
 
         assertThrows(RfcInvalidStatusException.class,
-                () -> rfcService.addAlternative(rfcId, userId, request));
+                () -> rfcService.addAlternative(rfcId, userId, request, null));
     }
 
     @Test
@@ -275,40 +289,62 @@ class RfcServiceTest {
 
         when(rfcRepository.findById(rfcId)).thenReturn(Optional.of(rfc));
 
-        CreateAlternativeRequest request = new CreateAlternativeRequest("Alt", "Desc", "Pros", "Cons");
+        CreateAlternativeRequest request = new CreateAlternativeRequest("Alt", "Desc", "Pros", "Cons", null);
 
         assertThrows(RfcAlternativeNotAllowedException.class,
-                () -> rfcService.addAlternative(rfcId, userId, request));
+                () -> rfcService.addAlternative(rfcId, userId, request, null));
     }
 
     @Test
-    void addAlternative_shouldCreateAlternative_whenAuthorAndUnderReview() {
+    void addAlternative_shouldCreateAlternative_whenAuthorAndUnderReview() throws IOException {
         Long rfcId = 1L;
         Long userId = 1L;
+        Long orgId = 10L;
 
-        User author = new User();
-        author.setId(userId);
+        User author = new User(); author.setId(userId);
+        Organization org = new Organization(); org.setId(orgId);
 
         RFC rfc = new RFC();
         rfc.setId(rfcId);
         rfc.setStatus(RFC.Status.UNDER_REVIEW);
         rfc.setUser(author);
+        rfc.setOrg(org);
 
-        CreateAlternativeRequest request = new CreateAlternativeRequest("Alt", "Desc", "Pros", "Cons");
+        CreateAlternativeRequest request = new CreateAlternativeRequest("Alt", "Desc", "Pros", "Cons", null);
 
+        // 1. Mock find RFC
         when(rfcRepository.findById(rfcId)).thenReturn(Optional.of(rfc));
+
+        // 2. Mock save Alternative
         when(alternativeRepository.save(any(Alternative.class)))
                 .thenAnswer(invocation -> {
                     Alternative a = invocation.getArgument(0);
-                    a.setId(10L);
+                    a.setId(10L); // Simuliamo ID generato
                     return a;
                 });
 
-        AlternativeResponse response = rfcService.addAlternative(rfcId, userId, request);
+        // 3. Mock retrieve Alternative per costruire la Response (il service chiama getAlternativeByIdForOrg alla fine)
+        when(alternativeRepository.findById(10L)).thenAnswer(inv -> {
+            Alternative a = new Alternative();
+            a.setId(10L);
+            a.setRfc(rfc);
+            a.setAuthor(author);
+            a.setTitle("Alt");
+            a.setDescription("Desc");
+            return Optional.of(a);
+        });
+
+        // 4. Mock dependencies per Response
+        when(alternativeAttachmentRepository.findByAlternativeId(10L)).thenReturn(Collections.emptyList());
+        when(voteRepository.countByAlternativeAndOutcome(any(), eq(true))).thenReturn(0);
+        when(voteRepository.countByAlternativeAndOutcome(any(), eq(false))).thenReturn(0);
+
+        AlternativeSpecificResponse response = rfcService.addAlternative(rfcId, userId, request, null);
 
         assertNotNull(response);
         verify(alternativeRepository).save(any(Alternative.class));
     }
+
 
     // ------------------------------------------------------------
     // closeRfc
@@ -411,5 +447,188 @@ class RfcServiceTest {
         assertEquals(0, response.yesCount());
         assertEquals(0, response.noCount());
         verify(voteRepository).delete(existing);
+    }
+
+    @Test
+    void updateOrCreateDiagram_shouldUpdateXml_whenAuthor() {
+        Long rfcId = 100L;
+        Long userId = 1L;
+        String newXml = "<xml>Diagram</xml>";
+
+        User author = new User(); author.setId(userId);
+        Organization org = new Organization(); org.setId(5L);
+        RFC rfc = new RFC();
+        rfc.setId(rfcId);
+        rfc.setUser(author);
+        rfc.setOrg(org);
+        rfc.setStatus(RFC.Status.UNDER_REVIEW);
+
+        when(rfcRepository.findById(rfcId)).thenReturn(Optional.of(rfc));
+        // Mock per la risposta
+        when(rfcRepository.findByIdAndOrgId(rfcId, 5L)).thenReturn(Optional.of(rfc));
+        when(rfcAttachmentRepository.findByRfcId(rfcId)).thenReturn(Collections.emptyList());
+        when(commentRepository.findByRfcId(rfcId)).thenReturn(Collections.emptyList());
+        when(alternativeRepository.findByRfcId(rfcId)).thenReturn(Collections.emptyList());
+
+        RfcSpecificResponse response = rfcService.updateOrCreateDiagram(rfcId, userId, newXml);
+
+        assertEquals(newXml, rfc.getXml());
+        verify(rfcRepository).save(rfc);
+    }
+
+    @Test
+    void updateOrCreateAlternativeDiagram_shouldUpdateXml() {
+        Long altId = 200L;
+        Long userId = 1L;
+        String newXml = "<xml>AltDiagram</xml>";
+
+        User author = new User(); author.setId(userId);
+        Organization org = new Organization(); org.setId(5L);
+        RFC rfc = new RFC(); rfc.setOrg(org); rfc.setStatus(RFC.Status.UNDER_REVIEW);
+
+        Alternative alt = new Alternative();
+        alt.setId(altId);
+        alt.setAuthor(author);
+        alt.setRfc(rfc);
+
+        when(alternativeRepository.findById(altId)).thenReturn(Optional.of(alt));
+        when(alternativeAttachmentRepository.findByAlternativeId(altId)).thenReturn(Collections.emptyList());
+
+        AlternativeSpecificResponse response = rfcService.updateOrCreateAlternativeDiagram(altId, userId, newXml);
+
+        assertEquals(newXml, alt.getXml());
+        verify(alternativeRepository).save(alt);
+    }
+
+    // =========================================================================
+    // 4. ATTACHMENT UPLOAD/DOWNLOAD (New)
+    // =========================================================================
+
+    @Test
+    void uploadMultipleAttachments_shouldSaveFiles_RFC() throws IOException {
+        Long rfcId = 100L;
+        Long userId = 1L;
+        RFC rfc = new RFC(); rfc.setId(rfcId);
+
+        when(rfcRepository.findById(rfcId)).thenReturn(Optional.of(rfc));
+
+        MockMultipartFile file = new MockMultipartFile("files", "doc.pdf", "application/pdf", "data".getBytes());
+
+        List<RfcAttachment> result = rfcService.uploadMultipleAttachments(rfcId, userId, List.of(file));
+
+        assertEquals(1, result.size());
+        verify(rfcAttachmentRepository).save(any(RfcAttachment.class));
+    }
+
+    @Test
+    void downloadRfcAttachment_shouldReturnResource_whenAuthorized(@TempDir Path tempDir) throws IOException {
+        // Creiamo un file temporaneo reale per evitare errori di 'file not found'
+        Path tempFile = Files.createFile(tempDir.resolve("test.txt"));
+        Files.writeString(tempFile, "Content");
+
+        Long attId = 10L;
+        Long userOrgId = 50L;
+
+        Organization org = new Organization(); org.setId(userOrgId);
+        RFC rfc = new RFC(); rfc.setOrg(org);
+
+        RfcAttachment attachment = new RfcAttachment();
+        attachment.setId(attId);
+        attachment.setRfc(rfc);
+        attachment.setFileName("test.txt");
+        attachment.setFilePath(tempFile.toAbsolutePath().toString());
+
+        when(rfcAttachmentRepository.findById(attId)).thenReturn(Optional.of(attachment));
+
+        RfcService.FileDownloadDTO result = rfcService.downloadRfcAttachment(attId, userOrgId);
+
+        assertNotNull(result.resource());
+        assertTrue(result.resource().exists());
+    }
+
+    @Test
+    void downloadRfcAttachment_shouldThrowForbidden_whenWrongOrg() {
+        Long attId = 10L;
+        Long userOrgId = 99L; // Wrong ID
+
+        Organization org = new Organization(); org.setId(50L);
+        RFC rfc = new RFC(); rfc.setOrg(org);
+        RfcAttachment attachment = new RfcAttachment();
+        attachment.setId(attId);
+        attachment.setRfc(rfc);
+
+        when(rfcAttachmentRepository.findById(attId)).thenReturn(Optional.of(attachment));
+
+        assertThrows(RfcAlternativeNotAllowedException.class,
+                () -> rfcService.downloadRfcAttachment(attId, userOrgId));
+    }
+
+    // =========================================================================
+    // 5. UPDATE TEXT FIELDS (Including 'Addition')
+    // =========================================================================
+
+    @Test
+    void updateRfcText_shouldUpdateAddition_whenProvided() {
+        Long rfcId = 100L;
+        Long userId = 1L;
+        Long orgId = 10L;
+
+        User author = new User(); author.setId(userId);
+        RFC rfc = new RFC();
+        rfc.setId(rfcId);
+        rfc.setUser(author);
+        rfc.setStatus(RFC.Status.UNDER_REVIEW);
+        Organization org = new Organization(); org.setId(orgId);
+        rfc.setOrg(org);
+
+        // UpdateRequest: (title, description, ADDITION)
+        UpdateRfcRequest request = new UpdateRfcRequest("New Title", "New Desc", "My Addition Note");
+
+        when(rfcRepository.findByIdAndOrgId(rfcId, orgId)).thenReturn(Optional.of(rfc));
+        // Mock getRfcByIdForOrg return
+        when(rfcAttachmentRepository.findByRfcId(rfcId)).thenReturn(Collections.emptyList());
+        when(commentRepository.findByRfcId(rfcId)).thenReturn(Collections.emptyList());
+        when(alternativeRepository.findByRfcId(rfcId)).thenReturn(Collections.emptyList());
+
+        RfcSpecificResponse response = rfcService.updateRfcText(rfcId, userId, orgId, request);
+
+        // Verifiche
+        ArgumentCaptor<RFC> captor = ArgumentCaptor.forClass(RFC.class);
+        verify(rfcRepository).save(captor.capture());
+
+        RFC saved = captor.getValue();
+        assertEquals("New Title", saved.getTitle());
+        assertEquals("My Addition Note", saved.getAddition()); // Verifica campo addition
+    }
+
+    @Test
+    void updateAlternative_shouldUpdateAddition_whenProvided() {
+        Long altId = 200L;
+        Long userId = 1L;
+
+        User author = new User(); author.setId(userId);
+        Organization org = new Organization(); org.setId(5L);
+        RFC rfc = new RFC();
+        rfc.setOrg(org);
+        rfc.setStatus(RFC.Status.UNDER_REVIEW);
+
+        Alternative alt = new Alternative();
+        alt.setId(altId);
+        alt.setAuthor(author);
+        alt.setRfc(rfc);
+
+        // UpdateRequest: (title, description, pros, cons, ADDITION)
+        UpdateAlternativeRequest request = new UpdateAlternativeRequest(
+                "T", "D", "P", "C", "Alt Addition");
+
+        when(alternativeRepository.findById(altId)).thenReturn(Optional.of(alt));
+        when(alternativeAttachmentRepository.findByAlternativeId(altId)).thenReturn(Collections.emptyList());
+
+        AlternativeSpecificResponse response = rfcService.updateAlternative(altId, userId, request);
+
+        ArgumentCaptor<Alternative> captor = ArgumentCaptor.forClass(Alternative.class);
+        verify(alternativeRepository).save(captor.capture());
+
+        assertEquals("Alt Addition", captor.getValue().getAddition());
     }
 }


### PR DESCRIPTION
Possibility, for both RFCs and alternatives, to add diagram and downloadable attachments (both in creation phase or later). Possibility also to edit fields and add text in a dedicated section.