### PR TITLE
Issues 67 68

### DIFF
--- a/src/main/java/dsd/api/cdmsa/controller/MeController.java
+++ b/src/main/java/dsd/api/cdmsa/controller/MeController.java
@@ -1,5 +1,7 @@
 package dsd.api.cdmsa.controller;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.web.PagedResourcesAssembler;
 import dsd.api.cdmsa.dto.UpdateUserProfileRequest;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import dsd.api.cdmsa.assembler.NotificationResponseModelAssembler;
 import dsd.api.cdmsa.assembler.OrgModelAssembler;
 import dsd.api.cdmsa.assembler.UserResponseModelAssembler;
+import dsd.api.cdmsa.dto.ContextByAdminResponse;
 import dsd.api.cdmsa.dto.NotificationResponse;
 import dsd.api.cdmsa.dto.NotificationStatusResponse;
 import dsd.api.cdmsa.dto.OrganizationResponseAlt;
@@ -22,6 +25,7 @@ import dsd.api.cdmsa.model.Notification;
 import dsd.api.cdmsa.model.Organization;
 import dsd.api.cdmsa.model.User;
 import dsd.api.cdmsa.model.UserPrincipal;
+import dsd.api.cdmsa.service.ContextService;
 import dsd.api.cdmsa.service.NotificationService;
 import dsd.api.cdmsa.service.OrgService;
 import lombok.AllArgsConstructor;
@@ -35,6 +39,7 @@ public class MeController {
     private final OrgService orgService;
     private final NotificationService notiService;
     private final UserService userService;
+    private final ContextService contextService;
 
     private UserResponseModelAssembler userResponseModelAssembler;
     private OrgModelAssembler orgModelAssembler;
@@ -110,6 +115,17 @@ public class MeController {
         User response = userService.updateUserProfile(userId, request);
 
         return ResponseEntity.ok(userResponseModelAssembler.toModel(response));
+    }
+
+    // Get context IDs where the user is an admin
+    @GetMapping("/contexts/admin")
+    public ResponseEntity<List<ContextByAdminResponse>> getAdminContextIds(
+            @AuthenticationPrincipal UserPrincipal principal) {
+
+        User user = principal.getUser();
+        List<ContextByAdminResponse> contextIds = contextService.findContextByAdmin(user);
+        
+        return ResponseEntity.ok(contextIds);
     }
 
 }

--- a/src/main/java/dsd/api/cdmsa/controller/RfcController.java
+++ b/src/main/java/dsd/api/cdmsa/controller/RfcController.java
@@ -136,7 +136,9 @@ public class RfcController {
             @AuthenticationPrincipal UserPrincipal principal) {
 
         User user = principal.getUser();
-        RfcSpecificResponse response = rfcService.getRfcByIdForOrg(rfcId, principal.getOrgId(), user.getId());
+        boolean isReviewer = rfcService.isReviewer(user, rfcId);
+
+        RfcSpecificResponse response = rfcService.getRfcByIdForOrg(rfcId, principal.getOrgId(), user.getId(), isReviewer);
 
         return ResponseEntity.ok(response);
     }
@@ -203,14 +205,12 @@ public class RfcController {
     }
 
     @PostMapping("/alternatives/{altId}/vote")
-    @PreAuthorize("@permissionService.canReviewRfc(principal,#altId)")
+    @PreAuthorize("@permissionService.canVoteRfc(principal,#altId)")
     public ResponseEntity<VoteResponse> voteForAlternative(
             @PathVariable Long altId,
             @RequestBody VoteRequest voteRequest,
             @AuthenticationPrincipal UserPrincipal principal) {
-
-        // check if user is a reviewer, probably we need also the rfcId to see status =
-        // under review
+        
         User user = principal.getUser();
 
         VoteResponse resp = rfcService.voteForAlternative(altId, user.getId(), voteRequest.outcome());

--- a/src/main/java/dsd/api/cdmsa/dto/CreateRfcRequest.java
+++ b/src/main/java/dsd/api/cdmsa/dto/CreateRfcRequest.java
@@ -1,9 +1,13 @@
 package dsd.api.cdmsa.dto;
 
+import java.util.List;
+
 public record CreateRfcRequest(
         String title,
         String description,
         Long templateId,
-        String xml  // if null no diagram has been created (yet)
+        String xml,  // if null no diagram has been created (yet)
+        List<Long> userReviewerIds,
+        List<Long> contextReviewerIds
         ) {
 }

--- a/src/main/java/dsd/api/cdmsa/dto/RfcSpecificResponse.java
+++ b/src/main/java/dsd/api/cdmsa/dto/RfcSpecificResponse.java
@@ -21,6 +21,7 @@ public record RfcSpecificResponse(
         String xml,
         boolean isAuthor,
         boolean isWatching,
+        boolean isReviewer,
         List<EntityModel<UserSummaryResponse>> userReviewers,
         List<EntityModel<ContextSummaryResponse>> contextReviewers,
         List<AlternativeResponse> alternatives,

--- a/src/main/java/dsd/api/cdmsa/dto/UserSummaryResponse.java
+++ b/src/main/java/dsd/api/cdmsa/dto/UserSummaryResponse.java
@@ -7,11 +7,15 @@ import dsd.api.cdmsa.model.User;
 @Relation(collectionRelation = "users")
 public record UserSummaryResponse(
         Long id,
-        String email) {
+        String email,
+        String firstname,
+        String lastName) {
 
     public static UserSummaryResponse fromEntity(User user) {
         return new UserSummaryResponse(
                 user.getId(),
-                user.getEmail());
+                user.getEmail(),
+                user.getFirstname(),
+                user.getLastname());
     }
 }

--- a/src/main/java/dsd/api/cdmsa/model/RFC.java
+++ b/src/main/java/dsd/api/cdmsa/model/RFC.java
@@ -32,7 +32,7 @@ public class RFC {
     @Column(nullable = false, length = 100)
     private String title;
 
-    @Column(length = 500)
+    @Column(length = 3000)
     private String description;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/dsd/api/cdmsa/repository/ContextReviewerRepository.java
+++ b/src/main/java/dsd/api/cdmsa/repository/ContextReviewerRepository.java
@@ -12,5 +12,7 @@ import dsd.api.cdmsa.model.RFC;
 @Repository
 public interface ContextReviewerRepository extends JpaRepository<ContextReviewer, ContextRFCId> {
     List<ContextReviewer> findAllByRfc(RFC rfc);
+
+    void deleteByRfcId(Long rfcId);
     
 }

--- a/src/main/java/dsd/api/cdmsa/repository/UserReviewerRepository.java
+++ b/src/main/java/dsd/api/cdmsa/repository/UserReviewerRepository.java
@@ -12,5 +12,7 @@ import dsd.api.cdmsa.model.UserReviewer;
 @Repository
 public interface UserReviewerRepository extends JpaRepository<UserReviewer, UserRFCId> {
     List<UserReviewer> findAllByRfc(RFC rfc);
+
+    void deleteByRfcId(Long rfcId);
     
 }

--- a/src/main/java/dsd/api/cdmsa/service/ContextService.java
+++ b/src/main/java/dsd/api/cdmsa/service/ContextService.java
@@ -429,15 +429,15 @@ public class ContextService {
     @Transactional(readOnly = true)
     public List<ContextMemberResponse> listMembers(Long actingUserId, Long contextId) {
 
-        User actingUser = getCurrentUserOrThrow(actingUserId);
+        // User actingUser = getCurrentUserOrThrow(actingUserId);
         Context context = contextRepository.findById(contextId)
                 .orElseThrow(() -> new ContextNotFoundException("Context not found"));
 
-        // only org admins or context admins can list members
-        if (!isContextAdmin(actingUser, context.getId())) {
-            throw new ContextForbiddenException(
-                    "Only organization admins or context admins can view context members");
-        }
+        // // only org admins or context admins can list members
+        // if (!isContextAdmin(actingUser, context.getId())) {
+        //     throw new ContextForbiddenException(
+        //             "Only organization admins or context admins can view context members");
+        // }
 
         return membershipRepository.findByContextId(contextId)
                 .stream()

--- a/src/main/java/dsd/api/cdmsa/service/OrgService.java
+++ b/src/main/java/dsd/api/cdmsa/service/OrgService.java
@@ -129,6 +129,10 @@ public class OrgService {
                                 .orElseThrow(() -> new RuntimeException("User not found"));
                 Organization org = user.getOrg();
 
+                if (!org.getAdminUser().getId().equals(user.getId())) {
+                        throw new RuntimeException("Only admin can update organization details");
+                }
+
                 org.setName(request.companyName().trim());
                 org.setDescription(request.description().trim());
                 org.setDomain(request.domain().trim());
@@ -151,6 +155,10 @@ public class OrgService {
                 User user = userRepo.findById(userId)
                                 .orElseThrow(() -> new RuntimeException("User not found"));
                 Organization org = user.getOrg();
+
+                if (!org.getAdminUser().getId().equals(user.getId())) {
+                        throw new RuntimeException("Only admin can connect GitHub");
+                }
 
                 String pat = request.pat().trim();
 
@@ -241,6 +249,10 @@ public class OrgService {
                 User user = userRepo.findById(userId)
                                 .orElseThrow(() -> new RuntimeException("User not found"));
                 Organization org = user.getOrg();
+
+                if (!org.getAdminUser().getId().equals(user.getId())) {
+                        throw new RuntimeException("Only admin can set repo and branch");
+                }
 
                 org.setSelectedRepoName(request.repoName().trim());
                 org.setSelectedBranchName(request.branchName().trim());

--- a/src/main/java/dsd/api/cdmsa/service/PermissionService.java
+++ b/src/main/java/dsd/api/cdmsa/service/PermissionService.java
@@ -2,7 +2,10 @@ package dsd.api.cdmsa.service;
 
 import org.springframework.stereotype.Service;
 
+import dsd.api.cdmsa.model.Alternative;
 import dsd.api.cdmsa.model.UserPrincipal;
+import dsd.api.cdmsa.repository.AlternativeRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -12,6 +15,7 @@ public class PermissionService {
     private final UserService userService;
     private final ContextService contextService;
     private final RfcService rfcService;
+    private final AlternativeRepository alternativeRepository;
 
     // === ORG PERMISSIONS ===
 
@@ -36,6 +40,16 @@ public class PermissionService {
     public boolean canReviewRfc(UserPrincipal principal, Long rfcId) {
         return rfcService.isReviewer(principal.getUser(),rfcId) ||
                 canManageRfc(principal,rfcId);
+    }
+
+    // == VOTER PERMISSION ===
+    public boolean canVoteRfc(UserPrincipal principal, Long altId) {
+        Alternative alternative = alternativeRepository.findById(altId)
+                .orElseThrow(() -> new EntityNotFoundException("Alternative not found"));
+        
+        Long rfcId = alternative.getRfc().getId();
+
+        return canReviewRfc(principal, rfcId);
     }
 
 }

--- a/src/main/java/dsd/api/cdmsa/service/RfcService.java
+++ b/src/main/java/dsd/api/cdmsa/service/RfcService.java
@@ -213,7 +213,10 @@ public class RfcService {
 
         ingestionService.ingestRFC(saved);
 
-        asignReviewersToRfc(new ReviewersRequest(List.of(userId), null), saved.getId(), orgId);
+        if (request.userReviewerIds() != null || request.contextReviewerIds() != null) {
+            ReviewersRequest reviewers = new ReviewersRequest(request.userReviewerIds(), request.contextReviewerIds());
+            asignReviewersToRfc(reviewers, saved.getId(), orgId);
+        }
 
         // Check attachments presence
         if (files != null && !files.isEmpty()) {
@@ -331,7 +334,7 @@ public class RfcService {
      * ensure organization-scoped access to RFC details.
      */
     @Transactional(readOnly = true)
-    public RfcSpecificResponse getRfcByIdForOrg(Long rfcId, Long orgId, Long userId) {
+    public RfcSpecificResponse getRfcByIdForOrg(Long rfcId, Long orgId, Long userId, boolean isReviewer) {
 
         RFC rfc = rfcRepository.findByIdAndOrgId(rfcId, orgId)
                 .orElseThrow(() -> new RfcNotFoundException("RFC not found with id " + rfcId));
@@ -365,6 +368,7 @@ public class RfcService {
                 rfc.getXml(),
                 isAuthor,
                 isWatching,
+                isReviewer,
                 userReviewers,
                 contextReviewrs,
                 detailedRfc.alternatives(),
@@ -638,9 +642,14 @@ public class RfcService {
     public void asignReviewersToRfc(ReviewersRequest reviewers, Long rfcId, Long orgId) {
 
         List<Long> userIds = reviewers.userIds();
-        List<Long> contetxIds = reviewers.contextIds();
+        List<Long> contextIds = reviewers.contextIds();
         RFC rfc = getRfcById(rfcId);
 
+        // Remove existing reviewers
+        userReviewerRepository.deleteByRfcId(rfcId);
+        contextReviewerRepository.deleteByRfcId(rfcId);
+
+        // Add new user reviewers
         if (userIds != null && !userIds.isEmpty()) {
             List<User> users = userService.findAllUsersByid(userIds, orgId);
 
@@ -656,8 +665,9 @@ public class RfcService {
             userReviewerRepository.saveAll(userReviewers);
         }
 
-        if (contetxIds != null && !contetxIds.isEmpty()) {
-            List<Context> contexts = contextService.findAllContextByid(contetxIds);
+        // Add new context reviewers
+        if (contextIds != null && !contextIds.isEmpty()) {
+            List<Context> contexts = contextService.findAllContextByid(contextIds);
 
             List<ContextReviewer> contextReviewers = contexts.stream()
                     .map(context -> {
@@ -731,7 +741,7 @@ public class RfcService {
         rfc.setXml(xmlContent != null ? xmlContent.trim() : null);
 
         rfcRepository.save(rfc);
-        return getRfcByIdForOrg(rfcId, rfc.getOrg().getId(), userId);
+        return getRfcByIdForOrg(rfcId, rfc.getOrg().getId(), userId, true);
     }
 
     @Transactional
@@ -838,7 +848,7 @@ public class RfcService {
         RFC saved = rfcRepository.save(rfc);
         ingestionService.ingestRFC(saved);
 
-        return getRfcByIdForOrg(rfcId, orgId, userId);
+        return getRfcByIdForOrg(rfcId, orgId, userId, true);
     }
 
     @Transactional

--- a/src/test/java/dsd/api/cdmsa/unit/RfcServiceTest.java
+++ b/src/test/java/dsd/api/cdmsa/unit/RfcServiceTest.java
@@ -122,6 +122,8 @@ class RfcServiceTest {
                 "  My RFC  ",
                 "Desc",
                 templateId,
+                null,
+                null,
                 null);
 
         User author = new User(); author.setId(userId);
@@ -175,7 +177,10 @@ class RfcServiceTest {
                 "  ",
                 "Desc",
                 1L,
-                null);
+                null,
+                null,
+                null
+            );
 
         assertThrows(RfcBadRequestException.class,
                 () -> rfcService.createRfc(1L, 10L, request, null));


### PR DESCRIPTION
This PR covers issues #67 and #68 - as well as parts of frontend issues 87 (https://github.com/CDMSA-DSD/frontend/issues/87) and 88 (https://github.com/CDMSA-DSD/frontend/issues/88).

Changes made:

- Updates the RFC description limit to 3000 characters
- Adds a 'me/contexts/admin' endpoint that returns the id's of the contexts the user is an admin of
- Allows regular users to see the members of a context
- Adds permission checking on organization updates
- Fixes alternative voting
- Returns if a user is permitted to review an RFC when querying the specific rfc GET
- Allows users to create an RFC with set reviewers