### PR TITLE
Fix bug always using localhost:3000 for CORS that caused fails to Req…

### DIFF
--- a/src/main/java/dsd/api/cdmsa/config/SecurityConfig.java
+++ b/src/main/java/dsd/api/cdmsa/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package dsd.api.cdmsa.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -27,14 +28,19 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+
 
 @Configuration
 @EnableMethodSecurity
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class SecurityConfig {
 
     private final UserDetailsService userDetailsService;
     private final JwtFilter jwtFilter;
+
+    @Value("${app.frontend.base-url}")
+    private String frontendBaseURL;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -99,7 +105,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         // Allow the frontend dev server explicitly; don't use wildcard with credentials
-        configuration.setAllowedOrigins(java.util.Arrays.asList("http://localhost:3000"));
+        configuration.setAllowedOrigins(java.util.Arrays.asList(frontendBaseURL));
         configuration.setAllowedMethods(java.util.Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         configuration.setAllowedHeaders(java.util.Arrays.asList("Authorization", "Content-Type", "Accept", "Origin"));
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
Fix #71 

What changed :
Added annotation to `securityConfig.java`, it will use the site frontend url in the yml file (`app.frontend.base-url`) on `configuration.setAllowedOrigins`